### PR TITLE
Set dependabot up to automerge patch updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -14,9 +14,13 @@ update_configs:
 
   - package_manager: javascript
     directory: /
-    update_schedule: live
+    update_schedule: daily
     allowed_updates:
       - match:
           dependency_type: all
           update_type: all
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
     version_requirement_updates: increase_versions


### PR DESCRIPTION
They should only be bug fixes or minor changes, and it saves on having to review them all, allowing us to focus on things that introduce new features.

Depends on #17 being merged and branch rules being set up to check for CI passing.