### PR TITLE
Automerge minor version changes to Babel packages

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -23,4 +23,7 @@ update_configs:
       - match:
           dependency_type: all
           update_type: semver:patch
+      - match:
+          dependency_type: "@babel/*"
+          update_type: semver:minor
     version_requirement_updates: increase_versions


### PR DESCRIPTION
They change fairly frequently, and there are lots of them. We don't need
to monitor minor changes, since we're not really relying on them
directly.