### PR TITLE
Use the boilerplate Terraform for MaT to deploy to AWS

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
+.terraform/
 .vscode/
 
 node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.terraform/
 .vscode/
 
 node_modules/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
+.terraform/
 .vscode/
 
 .github/CODEOWNERS
@@ -13,6 +14,7 @@ Dockerfile
 LICENCE
 *.feature
 *.snap
+*.tf
 .*
 !.*.*
 !.*/

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,48 @@
+provider "aws" {
+  region  = "eu-west-2"
+  version = "~> 2.0"
+}
+
+provider "template" {
+  version = "~> 2.0"
+}
+
+data "aws_iam_role" "ec2_container_service_role" {
+  name = "ecsServiceRole"
+}
+
+data "aws_iam_role" "ecs_task_execution_role" {
+  name = "ecsTaskExecutionRole"
+}
+
+module "development" {
+  # We pin to `master` for now, until we have tagged releases of the modules.
+  source = "git@github.com:LBHackney-IT/aws-mat-components-per-service-terraform.git//modules/environment/frontend?ref=master"
+
+  environment_name = "development"
+  application_name = "thc"
+
+  security_group_name_prefix = "mat-frontend-sg"
+  lb_prefix                  = "hackney-ext-mat-alb"
+
+  # Note that this process should only use ports in the 200X range to avoid port
+  # clashes.
+  port = 2001
+
+  listener_port = 80
+  path_pattern  = "thc"
+
+  desired_number_of_ec2_nodes = 2
+
+  ecs_execution_role = "${data.aws_iam_role.ecs_task_execution_role.arn}"
+  lb_iam_role_arn    = "${data.aws_iam_role.ec2_container_service_role.arn}"
+
+  task_definition_environment_variables = {
+    NODE_ENV = "production"
+  }
+
+  task_definition_environment_variable_count = 1
+
+  task_definition_secrets      = {}
+  task_definition_secret_count = 0
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -7,6 +7,15 @@ provider "template" {
   version = "~> 2.0"
 }
 
+terraform {
+  backend "s3" {
+    bucket  = "hackney-mat-state-storage-s3"
+    encrypt = true
+    region  = "eu-west-2"
+    key     = "services/thc/state"
+  }
+}
+
 data "aws_iam_role" "ec2_container_service_role" {
   name = "ecsServiceRole"
 }


### PR DESCRIPTION
For now we pin directly to `master`, as the repo hasn't been tagged with a release, yet.