### PR TITLE
Add processRef to corresponding places

### DIFF
--- a/steps/previsit/about-visit.tsx
+++ b/steps/previsit/about-visit.tsx
@@ -15,7 +15,7 @@ import { RadioButtons } from "../../components/RadioButtons";
 import { TextArea } from "../../components/TextArea";
 
 import DatabaseSchema from "../../storage/DatabaseSchema";
-import processId from "../../storage/processId";
+import processRef from "../../storage/processRef";
 
 const step: ProcessStepDefinition = {
   title: "About visit",
@@ -56,7 +56,7 @@ const step: ProcessStepDefinition = {
           },
           databaseMap: new DatabaseMap<DatabaseSchema, "unannouncedVisit">({
             storeName: "unannouncedVisit",
-            key: processId
+            key: processRef
           }),
           emptyValue: undefined
         })
@@ -72,7 +72,7 @@ const step: ProcessStepDefinition = {
           databaseMap: new DatabaseMap<DatabaseSchema, "unannouncedVisitNotes">(
             {
               storeName: "unannouncedVisitNotes",
-              key: processId
+              key: processRef
             }
           ),
           emptyValue: "",
@@ -110,7 +110,7 @@ const step: ProcessStepDefinition = {
           },
           databaseMap: new DatabaseMap<DatabaseSchema, "insideProperty">({
             storeName: "insideProperty",
-            key: processId
+            key: processRef
           }),
           emptyValue: undefined
         })
@@ -125,7 +125,7 @@ const step: ProcessStepDefinition = {
           },
           databaseMap: new DatabaseMap<DatabaseSchema, "insidePropertyNotes">({
             storeName: "insidePropertyNotes",
-            key: processId
+            key: processRef
           }),
           emptyValue: "",
           renderWhen: (values): boolean =>

--- a/storage/DatabaseSchema.ts
+++ b/storage/DatabaseSchema.ts
@@ -26,22 +26,22 @@ type DatabaseSchema = NamedSchema<
     };
 
     unannouncedVisit: {
-      key: string;
+      key: ProcessRef;
       value: string;
     };
 
     unannouncedVisitNotes: {
-      key: string;
+      key: ProcessRef;
       value: string;
     };
 
     insideProperty: {
-      key: string;
+      key: ProcessRef;
       value: string;
     };
 
     insidePropertyNotes: {
-      key: string;
+      key: ProcessRef;
       value: string;
     };
   }
@@ -50,7 +50,11 @@ type DatabaseSchema = NamedSchema<
 export const processStoreNames: StoreNames<DatabaseSchema["schema"]>[] = [
   "lastModified",
   "outsidePropertyImages",
-  "metalGateImages"
+  "metalGateImages",
+  "unannouncedVisit",
+  "unannouncedVisitNotes",
+  "insideProperty",
+  "insidePropertyNotes"
 ];
 
 export default DatabaseSchema;


### PR DESCRIPTION
ProcessId was still being used, which was causing the builds to break, has been replaced with processRef, also added the new stores to processStoreNames. 