### PR TITLE
Fix the sections page in end to end tests

### DIFF
--- a/__tests__/features/end-to-end.steps.ts
+++ b/__tests__/features/end-to-end.steps.ts
@@ -26,10 +26,11 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await expect(browser!.getCurrentUrl()).resolves.toContain("/loading");
 
       // Wait for data fetching.
-      await browser!.wait(
-        until.elementIsEnabled(
-          await browser!.findElement({ css: '[data-testid="submit"]' })
-        ),
+      await browser!.waitForEnabledElement(
+        {
+          css: '[data-testid="submit"]'
+        },
+        1000,
         10000
       );
 
@@ -41,10 +42,13 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       );
 
       await browser!
-        .findElement({ name: "outside-property-images" })
+        .waitForEnabledElement({
+          name: "outside-property-images"
+        })
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
+
       await browser!
-        .findElement({ name: "metal-gate-images" })
+        .waitForEnabledElement({ name: "metal-gate-images" })
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
 
       await browser!.submit();
@@ -57,13 +61,22 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       // About visit page
       await expect(browser!.getCurrentUrl()).resolves.toContain("/about-visit");
 
-      await browser!.findElement({ id: "unannounced-visit-no" }).click();
       await browser!
-        .wait(until.elementLocated({ name: "unannounced-visit-notes" }), 500)
+        .waitForEnabledElement({ id: "unannounced-visit-no" })
+        .click();
+
+      await browser!
+        .waitForEnabledElement({
+          name: "unannounced-visit-notes"
+        })
         .sendKeys("Unannounced visit notes");
-      await browser!.findElement({ id: "inside-property-no" }).click();
+
       await browser!
-        .wait(until.elementLocated({ name: "inside-property-notes" }), 500)
+        .waitForEnabledElement({ id: "inside-property-no" })
+        .click();
+
+      await browser!
+        .waitForEnabledElement({ name: "inside-property-notes" })
         .sendKeys("Inside property notes");
 
       await browser!.submit();
@@ -71,23 +84,24 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       // Sections page
       await expect(browser!.getCurrentUrl()).resolves.toContain("/sections");
 
-      await browser!.wait(until.elementLocated({ css: '[href="/id"]' }), 10000);
+      await browser!.waitForEnabledElement({ css: '[href="/id"]' }, 10000);
 
       await browser!.submit({ css: '[href="/id"]' });
 
       // ID page
       await expect(browser!.getCurrentUrl()).resolves.toContain("/id");
 
-      await browser!.findElement({ id: "id-type-valid-passport" }).click();
       await browser!
-        .findElement({ name: "id-proof-images" })
+        .waitForEnabledElement({ id: "id-type-valid-passport" })
+        .click();
+
+      await browser!
+        .waitForEnabledElement({ name: "id-proof-images" })
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
-      await browser!.findElement({ id: "id-notes-summary" }).click();
+
+      await browser!.waitForEnabledElement({ id: "id-notes-summary" }).click();
       await browser!
-        .wait(
-          until.elementIsVisible(browser!.findElement({ name: "id-notes" })),
-          500
-        )
+        .waitForEnabledElement({ name: "id-notes" })
         .sendKeys("ID notes");
 
       await browser!.submit();
@@ -96,19 +110,21 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await expect(browser!.getCurrentUrl()).resolves.toContain("/residency");
 
       await browser!
-        .findElement({ id: "residency-proof-type-bank-statement" })
+        .waitForEnabledElement({
+          id: "residency-proof-type-bank-statement"
+        })
         .click();
+
       await browser!
-        .findElement({ name: "residency-proof-images" })
+        .waitForEnabledElement({ name: "residency-proof-images" })
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
-      await browser!.findElement({ id: "residency-notes-summary" }).click();
+
       await browser!
-        .wait(
-          until.elementIsVisible(
-            browser!.findElement({ name: "residency-notes" })
-          ),
-          500
-        )
+        .waitForEnabledElement({ id: "residency-notes-summary" })
+        .click();
+
+      await browser!
+        .waitForEnabledElement({ name: "residency-notes" })
         .sendKeys("Residency notes");
 
       await browser!.submit();
@@ -118,9 +134,11 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
         "/tenant-photo"
       );
 
-      await browser!.findElement({ id: "tenant-photo-willing-yes" }).click();
       await browser!
-        .wait(until.elementLocated({ name: "tenant-photo" }), 500)
+        .waitForEnabledElement({ id: "tenant-photo-willing-yes" })
+        .click();
+      await browser!
+        .waitForEnabledElement({ name: "tenant-photo" })
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
 
       await browser!.submit();
@@ -129,22 +147,33 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await expect(browser!.getCurrentUrl()).resolves.toContain("/next-of-kin");
 
       await browser!
-        .findElement({ name: "next-of-kin-full-name" })
+        .waitForEnabledElement({ name: "next-of-kin-full-name" })
         .sendKeys("Full name");
+
       await browser!
-        .findElement({ name: "next-of-kin-relationship" })
+        .waitForEnabledElement({
+          name: "next-of-kin-relationship"
+        })
         .sendKeys("Relationship");
+
       await browser!
-        .findElement({ name: "next-of-kin-mobile-number" })
+        .waitForEnabledElement({
+          name: "next-of-kin-mobile-number"
+        })
         .sendKeys("Mobile number");
+
       await browser!
-        .findElement({ name: "next-of-kin-other-number" })
+        .waitForEnabledElement({
+          name: "next-of-kin-other-number"
+        })
         .sendKeys("Other number");
+
       await browser!
-        .findElement({ name: "next-of-kin-email" })
+        .waitForEnabledElement({ name: "next-of-kin-email" })
         .sendKeys("Email address");
+
       await browser!
-        .findElement({ name: "next-of-kin-address" })
+        .waitForEnabledElement({ name: "next-of-kin-address" })
         .sendKeys("Address");
 
       await browser!.submit();
@@ -152,42 +181,43 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       // Carer page
       await expect(browser!.getCurrentUrl()).resolves.toContain("/carer");
 
-      await browser!.findElement({ id: "carer-needed-yes" }).click();
+      await browser!.waitForEnabledElement({ id: "carer-needed-yes" }).click();
+
       await browser!
-        .wait(until.elementLocated({ id: "carer-type-registered" }), 500)
+        .waitForEnabledElement({ id: "carer-type-registered" })
         .click();
+
+      await browser!.waitForEnabledElement({ id: "carer-live-in-yes" }).click();
+
       await browser!
-        .wait(until.elementLocated({ id: "carer-live-in-yes" }), 500)
-        .click();
-      await browser!
-        .wait(
-          until.elementLocated({ name: "carer-live-in-start-date-month" }),
-          500
-        )
+        .waitForEnabledElement({
+          name: "carer-live-in-start-date-month"
+        })
         .sendKeys("1");
+
       await browser!
-        .wait(
-          until.elementLocated({ name: "carer-live-in-start-date-year" }),
-          500
-        )
+        .waitForEnabledElement({
+          name: "carer-live-in-start-date-year"
+        })
         .sendKeys("2019");
+
       await browser!
-        .wait(until.elementLocated({ name: "carer-full-name" }), 500)
+        .waitForEnabledElement({ name: "carer-full-name" })
         .sendKeys("Full name");
+
       await browser!
-        .wait(until.elementLocated({ name: "carer-relationship" }), 500)
+        .waitForEnabledElement({ name: "carer-relationship" })
         .sendKeys("Relationship");
+
       await browser!
-        .wait(until.elementLocated({ name: "carer-phone-number" }), 500)
+        .waitForEnabledElement({ name: "carer-phone-number" })
         .sendKeys("Phone number");
+
       await browser!
-        .wait(until.elementLocated({ id: "carer-notes-summary" }), 500)
+        .waitForEnabledElement({ id: "carer-notes-summary" })
         .click();
       await browser!
-        .wait(
-          until.elementIsVisible(browser!.findElement({ name: "carer-notes" })),
-          500
-        )
+        .waitForEnabledElement({ name: "carer-notes" })
         .sendKeys("Carer notes");
 
       await browser!.submit();
@@ -195,9 +225,12 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       // Rooms page
       await expect(browser!.getCurrentUrl()).resolves.toContain("/rooms");
 
-      await browser!.findElement({ id: "can-enter-all-rooms-no" }).click();
       await browser!
-        .wait(until.elementLocated({ name: "room-entry-notes" }), 500)
+        .waitForEnabledElement({ id: "can-enter-all-rooms-no" })
+        .click();
+
+      await browser!
+        .waitForEnabledElement({ name: "room-entry-notes" })
         .sendKeys("Room entry notes");
 
       await browser!.submit();
@@ -207,47 +240,69 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
         "/laminated-flooring"
       );
 
-      await browser!.findElement({ id: "has-laminated-flooring-yes" }).click();
       await browser!
-        .wait(until.elementLocated({ id: "has-permission-yes" }), 500)
+        .waitForEnabledElement({
+          id: "has-laminated-flooring-yes"
+        })
         .click();
+
       await browser!
-        .wait(until.elementLocated({ name: "laminated-flooring-images" }), 500)
+        .waitForEnabledElement({ id: "has-permission-yes" })
+        .click();
+
+      await browser!
+        .waitForEnabledElement({
+          name: "laminated-flooring-images"
+        })
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
+
       await browser!
-        .wait(until.elementLocated({ name: "laminated-flooring-notes" }), 500)
+        .waitForEnabledElement({
+          name: "laminated-flooring-notes"
+        })
         .sendKeys("Laminated flooring notes");
 
       await browser!.submit();
 
       // Structural changes page
-
       await expect(browser!.getCurrentUrl()).resolves.toContain(
         "/structural-changes"
       );
 
-      await browser!.findElement({ id: "has-structural-changes-yes" }).click();
       await browser!
-        .wait(until.elementLocated({ id: "changes-authorised-yes" }), 500)
+        .waitForEnabledElement({
+          id: "has-structural-changes-yes"
+        })
         .click();
+
       await browser!
-        .wait(until.elementLocated({ name: "structural-changes-images" }), 500)
+        .waitForEnabledElement({ id: "changes-authorised-yes" })
+        .click();
+
+      await browser!
+        .waitForEnabledElement({
+          name: "structural-changes-images"
+        })
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
+
       await browser!
-        .wait(until.elementLocated({ name: "structural-changes-notes" }), 500)
-        .sendKeys("Structural channges notes");
+        .waitForEnabledElement({
+          name: "structural-changes-notes"
+        })
+        .sendKeys("Structural changes notes");
 
       await browser!.submit();
 
       // Damage page
       await expect(browser!.getCurrentUrl()).resolves.toContain("/damage");
 
-      await browser!.findElement({ id: "has-damage-yes" }).click();
+      await browser!.waitForEnabledElement({ id: "has-damage-yes" }).click();
+
       await browser!
-        .wait(until.elementLocated({ name: "damage-images" }), 500)
+        .waitForEnabledElement({ name: "damage-images" })
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
       await browser!
-        .wait(until.elementLocated({ name: "damage-notes" }), 500)
+        .waitForEnabledElement({ name: "damage-notes" })
         .sendKeys("Damage notes");
 
       await browser!.submit();
@@ -255,12 +310,13 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       // Roof page
       await expect(browser!.getCurrentUrl()).resolves.toContain("/roof");
 
-      await browser!.findElement({ id: "has-access-yes" }).click();
+      await browser!.waitForEnabledElement({ id: "has-access-yes" }).click();
+
       await browser!
-        .wait(until.elementLocated({ id: "items-stored-on-roof-yes" }), 500)
+        .waitForEnabledElement({ id: "items-stored-on-roof-yes" })
         .click();
       await browser!
-        .wait(until.elementLocated({ name: "roof-notes" }), 500)
+        .waitForEnabledElement({ name: "roof-notes" })
         .sendKeys("Roof notes");
 
       await browser!.submit();
@@ -268,12 +324,15 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       // Loft page
       await expect(browser!.getCurrentUrl()).resolves.toContain("/loft");
 
-      await browser!.findElement({ id: "has-access-to-loft-yes" }).click();
       await browser!
-        .wait(until.elementLocated({ id: "items-stored-in-loft-yes" }), 500)
+        .waitForEnabledElement({ id: "has-access-to-loft-yes" })
+        .click();
+
+      await browser!
+        .waitForEnabledElement({ id: "items-stored-in-loft-yes" })
         .click();
       await browser!
-        .wait(until.elementLocated({ name: "loft-notes" }), 500)
+        .waitForEnabledElement({ name: "loft-notes" })
         .sendKeys("Loft notes");
 
       await browser!.submit();
@@ -281,18 +340,19 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       // Garden page
       await expect(browser!.getCurrentUrl()).resolves.toContain("/garden");
 
-      await browser!.findElement({ id: "has-garden-yes" }).click();
+      await browser!.waitForEnabledElement({ id: "has-garden-yes" }).click();
+
       await browser!
-        .wait(until.elementLocated({ id: "garden-type-private" }), 500)
+        .waitForEnabledElement({ id: "garden-type-private" })
         .click();
+
+      await browser!.waitForEnabledElement({ id: "is-maintained-yes" }).click();
+
       await browser!
-        .wait(until.elementLocated({ id: "is-maintained-yes" }), 500)
-        .click();
-      await browser!
-        .wait(until.elementLocated({ name: "garden-images" }), 500)
+        .waitForEnabledElement({ name: "garden-images" })
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
       await browser!
-        .wait(until.elementLocated({ name: "garden-notes" }), 500)
+        .waitForEnabledElement({ name: "garden-notes" })
         .sendKeys("Garden notes");
 
       await browser!.submit();
@@ -302,12 +362,18 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
         "/storing-materials"
       );
 
-      await browser!.findElement({ id: "is-storing-materials-yes" }).click();
       await browser!
-        .wait(until.elementLocated({ id: "further-action-required-yes" }), 500)
+        .waitForEnabledElement({ id: "is-storing-materials-yes" })
         .click();
+
       await browser!
-        .wait(until.elementLocated({ name: "stored-materials-notes" }), 500)
+        .waitForEnabledElement({
+          id: "further-action-required-yes"
+        })
+        .click();
+
+      await browser!
+        .waitForEnabledElement({ name: "stored-materials-notes" })
         .sendKeys("Stored materials notes");
 
       await browser!.submit();
@@ -315,12 +381,12 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       // Fire exit page
       await expect(browser!.getCurrentUrl()).resolves.toContain("/fire-exit");
 
-      await browser!.findElement({ id: "has-fire-exit-yes" }).click();
+      await browser!.waitForEnabledElement({ id: "has-fire-exit-yes" }).click();
+
+      await browser!.waitForEnabledElement({ id: "is-accessible-yes" }).click();
+
       await browser!
-        .wait(until.elementLocated({ id: "is-accessible-yes" }), 500)
-        .click();
-      await browser!
-        .wait(until.elementLocated({ name: "fire-exit-notes" }), 500)
+        .waitForEnabledElement({ name: "fire-exit-notes" })
         .sendKeys("Fire exit notes");
 
       await browser!.submit();
@@ -328,12 +394,13 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       // Smoke alarm page
       await expect(browser!.getCurrentUrl()).resolves.toContain("/smoke-alarm");
 
-      await browser!.findElement({ id: "has-smoke-alarm-yes" }).click();
       await browser!
-        .wait(until.elementLocated({ id: "is-working-yes" }), 500)
+        .waitForEnabledElement({ id: "has-smoke-alarm-yes" })
         .click();
+      await browser!.waitForEnabledElement({ id: "is-working-yes" }).click();
+
       await browser!
-        .wait(until.elementLocated({ name: "smoke-alarm-notes" }), 500)
+        .waitForEnabledElement({ name: "smoke-alarm-notes" })
         .sendKeys("Smoke alarm notes");
 
       await browser!.submit();
@@ -341,18 +408,24 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       // Metal gates page
       await expect(browser!.getCurrentUrl()).resolves.toContain("/metal-gates");
 
-      await browser!.findElement({ id: "has-metal-gates-yes" }).click();
       await browser!
-        .wait(
-          until.elementLocated({ id: "combustible-items-behind-gates-yes" }),
-          500
-        )
+        .waitForEnabledElement({ id: "has-metal-gates-yes" })
         .click();
+
       await browser!
-        .wait(until.elementLocated({ id: "further-action-required-yes" }), 500)
+        .waitForEnabledElement({
+          id: "combustible-items-behind-gates-yes"
+        })
         .click();
+
       await browser!
-        .wait(until.elementLocated({ name: "metal-gates-notes" }), 500)
+        .waitForEnabledElement({
+          id: "further-action-required-yes"
+        })
+        .click();
+
+      await browser!
+        .waitForEnabledElement({ name: "metal-gates-notes" })
         .sendKeys("Metal gates notes");
 
       await browser!.submit();
@@ -360,12 +433,16 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       // Door mats page
       await expect(browser!.getCurrentUrl()).resolves.toContain("/door-mats");
 
-      await browser!.findElement({ id: "has-placed-yes" }).click();
+      await browser!.waitForEnabledElement({ id: "has-placed-yes" }).click();
+
       await browser!
-        .wait(until.elementLocated({ id: "further-action-required-yes" }), 500)
+        .waitForEnabledElement({
+          id: "further-action-required-yes"
+        })
         .click();
+
       await browser!
-        .wait(until.elementLocated({ name: "door-mats-notes" }), 500)
+        .waitForEnabledElement({ name: "door-mats-notes" })
         .sendKeys("Door mats notes");
 
       await browser!.submit();
@@ -376,13 +453,19 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       );
 
       await browser!
-        .findElement({ id: "has-left-combustible-items-yes" })
+        .waitForEnabledElement({
+          id: "has-left-combustible-items-yes"
+        })
         .click();
+
       await browser!
-        .wait(until.elementLocated({ id: "further-action-required-yes" }), 500)
+        .waitForEnabledElement({
+          id: "further-action-required-yes"
+        })
         .click();
+
       await browser!
-        .wait(until.elementLocated({ name: "communal-areas-notes" }), 500)
+        .waitForEnabledElement({ name: "communal-areas-notes" })
         .sendKeys("Communal areas notes");
 
       await browser!.submit();
@@ -390,18 +473,21 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       // Pets page
       await expect(browser!.getCurrentUrl()).resolves.toContain("/pets");
 
-      await browser!.findElement({ id: "has-pets-yes" }).click();
-      await browser!.findElement({ id: "has-permission-yes" }).click();
-      await browser!.findElement({ id: "pet-type-bird" }).click();
-      await browser!.findElement({ id: "pet-type-rabbit" }).click();
+      await browser!.waitForEnabledElement({ id: "has-pets-yes" }).click();
       await browser!
-        .wait(until.elementLocated({ id: "has-permission-yes" }), 500)
+        .waitForEnabledElement({ id: "has-permission-yes" })
         .click();
+      await browser!.waitForEnabledElement({ id: "pet-type-bird" }).click();
+      await browser!.waitForEnabledElement({ id: "pet-type-rabbit" }).click();
       await browser!
-        .wait(until.elementLocated({ name: "pets-permission-images" }), 500)
+        .waitForEnabledElement({ id: "has-permission-yes" })
+        .click();
+
+      await browser!
+        .waitForEnabledElement({ name: "pets-permission-images" })
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
       await browser!
-        .wait(until.elementLocated({ name: "pets-notes" }), 500)
+        .waitForEnabledElement({ name: "pets-notes" })
         .sendKeys("Pets notes");
 
       await browser!.submit();
@@ -411,9 +497,14 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
         "/antisocial-behaviour"
       );
 
-      await browser!.findElement({ id: "tenant-understands-yes" }).click();
       await browser!
-        .wait(until.elementLocated({ name: "antisocial-behaviour-notes" }), 500)
+        .waitForEnabledElement({ id: "tenant-understands-yes" })
+        .click();
+
+      await browser!
+        .waitForEnabledElement({
+          name: "antisocial-behaviour-notes"
+        })
         .sendKeys("Antisocial behaviour notes");
 
       await browser!.submit();
@@ -424,10 +515,11 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       );
 
       await browser!
-        .findElement({ name: "other-comments-images" })
+        .waitForEnabledElement({ name: "other-comments-images" })
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
+
       await browser!
-        .findElement({ name: "other-comments-notes" })
+        .waitForEnabledElement({ name: "other-comments-notes" })
         .sendKeys("Other comments notes");
       await browser!.submit();
 

--- a/__tests__/features/end-to-end.steps.ts
+++ b/__tests__/features/end-to-end.steps.ts
@@ -46,7 +46,6 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
           name: "outside-property-images"
         })
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
-
       await browser!
         .waitForEnabledElement({ name: "metal-gate-images" })
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
@@ -64,17 +63,14 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await browser!
         .waitForEnabledElement({ id: "unannounced-visit-no" })
         .click();
-
       await browser!
         .waitForEnabledElement({
           name: "unannounced-visit-notes"
         })
         .sendKeys("Unannounced visit notes");
-
       await browser!
         .waitForEnabledElement({ id: "inside-property-no" })
         .click();
-
       await browser!
         .waitForEnabledElement({ name: "inside-property-notes" })
         .sendKeys("Inside property notes");
@@ -94,11 +90,9 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await browser!
         .waitForEnabledElement({ id: "id-type-valid-passport" })
         .click();
-
       await browser!
         .waitForEnabledElement({ name: "id-proof-images" })
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
-
       await browser!.waitForEnabledElement({ id: "id-notes-summary" }).click();
       await browser!
         .waitForEnabledElement({ name: "id-notes" })
@@ -114,15 +108,12 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
           id: "residency-proof-type-bank-statement"
         })
         .click();
-
       await browser!
         .waitForEnabledElement({ name: "residency-proof-images" })
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
-
       await browser!
         .waitForEnabledElement({ id: "residency-notes-summary" })
         .click();
-
       await browser!
         .waitForEnabledElement({ name: "residency-notes" })
         .sendKeys("Residency notes");
@@ -149,29 +140,24 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await browser!
         .waitForEnabledElement({ name: "next-of-kin-full-name" })
         .sendKeys("Full name");
-
       await browser!
         .waitForEnabledElement({
           name: "next-of-kin-relationship"
         })
         .sendKeys("Relationship");
-
       await browser!
         .waitForEnabledElement({
           name: "next-of-kin-mobile-number"
         })
         .sendKeys("Mobile number");
-
       await browser!
         .waitForEnabledElement({
           name: "next-of-kin-other-number"
         })
         .sendKeys("Other number");
-
       await browser!
         .waitForEnabledElement({ name: "next-of-kin-email" })
         .sendKeys("Email address");
-
       await browser!
         .waitForEnabledElement({ name: "next-of-kin-address" })
         .sendKeys("Address");
@@ -186,33 +172,26 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await browser!
         .waitForEnabledElement({ id: "carer-type-registered" })
         .click();
-
       await browser!.waitForEnabledElement({ id: "carer-live-in-yes" }).click();
-
       await browser!
         .waitForEnabledElement({
           name: "carer-live-in-start-date-month"
         })
         .sendKeys("1");
-
       await browser!
         .waitForEnabledElement({
           name: "carer-live-in-start-date-year"
         })
         .sendKeys("2019");
-
       await browser!
         .waitForEnabledElement({ name: "carer-full-name" })
         .sendKeys("Full name");
-
       await browser!
         .waitForEnabledElement({ name: "carer-relationship" })
         .sendKeys("Relationship");
-
       await browser!
         .waitForEnabledElement({ name: "carer-phone-number" })
         .sendKeys("Phone number");
-
       await browser!
         .waitForEnabledElement({ id: "carer-notes-summary" })
         .click();
@@ -222,13 +201,19 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
 
       await browser!.submit();
 
+      // Sections page
+      await expect(browser!.getCurrentUrl()).resolves.toContain("/sections");
+
+      await browser!.waitForEnabledElement({ css: '[href="/rooms"]' }, 10000);
+
+      await browser!.submit({ css: '[href="/rooms"]' });
+
       // Rooms page
       await expect(browser!.getCurrentUrl()).resolves.toContain("/rooms");
 
       await browser!
         .waitForEnabledElement({ id: "can-enter-all-rooms-no" })
         .click();
-
       await browser!
         .waitForEnabledElement({ name: "room-entry-notes" })
         .sendKeys("Room entry notes");
@@ -245,17 +230,14 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
           id: "has-laminated-flooring-yes"
         })
         .click();
-
       await browser!
         .waitForEnabledElement({ id: "has-permission-yes" })
         .click();
-
       await browser!
         .waitForEnabledElement({
           name: "laminated-flooring-images"
         })
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
-
       await browser!
         .waitForEnabledElement({
           name: "laminated-flooring-notes"
@@ -274,17 +256,14 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
           id: "has-structural-changes-yes"
         })
         .click();
-
       await browser!
         .waitForEnabledElement({ id: "changes-authorised-yes" })
         .click();
-
       await browser!
         .waitForEnabledElement({
           name: "structural-changes-images"
         })
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
-
       await browser!
         .waitForEnabledElement({
           name: "structural-changes-notes"
@@ -297,7 +276,6 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await expect(browser!.getCurrentUrl()).resolves.toContain("/damage");
 
       await browser!.waitForEnabledElement({ id: "has-damage-yes" }).click();
-
       await browser!
         .waitForEnabledElement({ name: "damage-images" })
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
@@ -311,7 +289,6 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await expect(browser!.getCurrentUrl()).resolves.toContain("/roof");
 
       await browser!.waitForEnabledElement({ id: "has-access-yes" }).click();
-
       await browser!
         .waitForEnabledElement({ id: "items-stored-on-roof-yes" })
         .click();
@@ -327,7 +304,6 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await browser!
         .waitForEnabledElement({ id: "has-access-to-loft-yes" })
         .click();
-
       await browser!
         .waitForEnabledElement({ id: "items-stored-in-loft-yes" })
         .click();
@@ -341,13 +317,10 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await expect(browser!.getCurrentUrl()).resolves.toContain("/garden");
 
       await browser!.waitForEnabledElement({ id: "has-garden-yes" }).click();
-
       await browser!
         .waitForEnabledElement({ id: "garden-type-private" })
         .click();
-
       await browser!.waitForEnabledElement({ id: "is-maintained-yes" }).click();
-
       await browser!
         .waitForEnabledElement({ name: "garden-images" })
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
@@ -365,13 +338,11 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await browser!
         .waitForEnabledElement({ id: "is-storing-materials-yes" })
         .click();
-
       await browser!
         .waitForEnabledElement({
           id: "further-action-required-yes"
         })
         .click();
-
       await browser!
         .waitForEnabledElement({ name: "stored-materials-notes" })
         .sendKeys("Stored materials notes");
@@ -382,9 +353,7 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await expect(browser!.getCurrentUrl()).resolves.toContain("/fire-exit");
 
       await browser!.waitForEnabledElement({ id: "has-fire-exit-yes" }).click();
-
       await browser!.waitForEnabledElement({ id: "is-accessible-yes" }).click();
-
       await browser!
         .waitForEnabledElement({ name: "fire-exit-notes" })
         .sendKeys("Fire exit notes");
@@ -411,19 +380,16 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await browser!
         .waitForEnabledElement({ id: "has-metal-gates-yes" })
         .click();
-
       await browser!
         .waitForEnabledElement({
           id: "combustible-items-behind-gates-yes"
         })
         .click();
-
       await browser!
         .waitForEnabledElement({
           id: "further-action-required-yes"
         })
         .click();
-
       await browser!
         .waitForEnabledElement({ name: "metal-gates-notes" })
         .sendKeys("Metal gates notes");
@@ -434,13 +400,11 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await expect(browser!.getCurrentUrl()).resolves.toContain("/door-mats");
 
       await browser!.waitForEnabledElement({ id: "has-placed-yes" }).click();
-
       await browser!
         .waitForEnabledElement({
           id: "further-action-required-yes"
         })
         .click();
-
       await browser!
         .waitForEnabledElement({ name: "door-mats-notes" })
         .sendKeys("Door mats notes");
@@ -457,13 +421,11 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
           id: "has-left-combustible-items-yes"
         })
         .click();
-
       await browser!
         .waitForEnabledElement({
           id: "further-action-required-yes"
         })
         .click();
-
       await browser!
         .waitForEnabledElement({ name: "communal-areas-notes" })
         .sendKeys("Communal areas notes");
@@ -482,7 +444,6 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await browser!
         .waitForEnabledElement({ id: "has-permission-yes" })
         .click();
-
       await browser!
         .waitForEnabledElement({ name: "pets-permission-images" })
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
@@ -500,7 +461,6 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await browser!
         .waitForEnabledElement({ id: "tenant-understands-yes" })
         .click();
-
       await browser!
         .waitForEnabledElement({
           name: "antisocial-behaviour-notes"
@@ -517,16 +477,32 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await browser!
         .waitForEnabledElement({ name: "other-comments-images" })
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
-
       await browser!
         .waitForEnabledElement({ name: "other-comments-notes" })
         .sendKeys("Other comments notes");
       await browser!.submit();
 
+      // Sections page
+      await expect(browser!.getCurrentUrl()).resolves.toContain("/sections");
+
+      await browser!.waitForEnabledElement(
+        { css: '[href="/home-check"]' },
+        10000
+      );
+
+      await browser!.submit({ css: '[href="/home-check"]' });
+
       // Home check page
       await expect(browser!.getCurrentUrl()).resolves.toContain("/home-check");
       await browser!.findElement({ id: "home-check-yes" }).click();
       await browser!.submit();
+
+      // Sections page
+      await expect(browser!.getCurrentUrl()).resolves.toContain("/sections");
+
+      await browser!.waitForEnabledElement({ css: '[href="/submit"]' }, 10000);
+
+      await browser!.submit({ css: '[href="/submit"]' });
 
       // Submit page
       await expect(browser!.getCurrentUrl()).resolves.toContain("/submit");

--- a/__tests__/features/end-to-end.steps.ts
+++ b/__tests__/features/end-to-end.steps.ts
@@ -75,7 +75,7 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
 
       await browser!.submit({ css: '[href="/id"]' });
 
-      // Id page
+      // ID page
       await expect(browser!.getCurrentUrl()).resolves.toContain("/id");
 
       await browser!.findElement({ id: "id-type-valid-passport" }).click();
@@ -203,15 +203,16 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await browser!.submit();
 
       // Laminated flooring page
-
       await expect(browser!.getCurrentUrl()).resolves.toContain(
         "/laminated-flooring"
       );
 
       await browser!.findElement({ id: "has-laminated-flooring-yes" }).click();
-      await browser!.findElement({ id: "has-permission-yes" }).click();
       await browser!
-        .findElement({ name: "laminated-flooring-images" })
+        .wait(until.elementLocated({ id: "has-permission-yes" }), 500)
+        .click();
+      await browser!
+        .wait(until.elementLocated({ name: "laminated-flooring-images" }), 500)
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
       await browser!
         .wait(until.elementLocated({ name: "laminated-flooring-notes" }), 500)
@@ -226,9 +227,11 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       );
 
       await browser!.findElement({ id: "has-structural-changes-yes" }).click();
-      await browser!.findElement({ id: "changes-authorised-yes" }).click();
       await browser!
-        .findElement({ name: "structural-changes-images" })
+        .wait(until.elementLocated({ id: "changes-authorised-yes" }), 500)
+        .click();
+      await browser!
+        .wait(until.elementLocated({ name: "structural-changes-images" }), 500)
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
       await browser!
         .wait(until.elementLocated({ name: "structural-changes-notes" }), 500)
@@ -241,7 +244,7 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
 
       await browser!.findElement({ id: "has-damage-yes" }).click();
       await browser!
-        .findElement({ name: "damage-images" })
+        .wait(until.elementLocated({ name: "damage-images" }), 500)
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
       await browser!
         .wait(until.elementLocated({ name: "damage-notes" }), 500)
@@ -253,7 +256,9 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await expect(browser!.getCurrentUrl()).resolves.toContain("/roof");
 
       await browser!.findElement({ id: "has-access-yes" }).click();
-      await browser!.findElement({ id: "items-stored-on-roof-yes" }).click();
+      await browser!
+        .wait(until.elementLocated({ id: "items-stored-on-roof-yes" }), 500)
+        .click();
       await browser!
         .wait(until.elementLocated({ name: "roof-notes" }), 500)
         .sendKeys("Roof notes");
@@ -264,7 +269,9 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await expect(browser!.getCurrentUrl()).resolves.toContain("/loft");
 
       await browser!.findElement({ id: "has-access-to-loft-yes" }).click();
-      await browser!.findElement({ id: "items-stored-in-loft-yes" }).click();
+      await browser!
+        .wait(until.elementLocated({ id: "items-stored-in-loft-yes" }), 500)
+        .click();
       await browser!
         .wait(until.elementLocated({ name: "loft-notes" }), 500)
         .sendKeys("Loft notes");
@@ -275,10 +282,14 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await expect(browser!.getCurrentUrl()).resolves.toContain("/garden");
 
       await browser!.findElement({ id: "has-garden-yes" }).click();
-      await browser!.findElement({ id: "garden-type-private" }).click();
-      await browser!.findElement({ id: "is-maintained-yes" }).click();
       await browser!
-        .findElement({ name: "garden-images" })
+        .wait(until.elementLocated({ id: "garden-type-private" }), 500)
+        .click();
+      await browser!
+        .wait(until.elementLocated({ id: "is-maintained-yes" }), 500)
+        .click();
+      await browser!
+        .wait(until.elementLocated({ name: "garden-images" }), 500)
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
       await browser!
         .wait(until.elementLocated({ name: "garden-notes" }), 500)
@@ -292,10 +303,12 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       );
 
       await browser!.findElement({ id: "is-storing-materials-yes" }).click();
-      await browser!.findElement({ id: "further-action-required-yes" }).click();
+      await browser!
+        .wait(until.elementLocated({ id: "further-action-required-yes" }), 500)
+        .click();
       await browser!
         .wait(until.elementLocated({ name: "stored-materials-notes" }), 500)
-        .sendKeys("Garden notes");
+        .sendKeys("Stored materials notes");
 
       await browser!.submit();
 
@@ -303,7 +316,9 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await expect(browser!.getCurrentUrl()).resolves.toContain("/fire-exit");
 
       await browser!.findElement({ id: "has-fire-exit-yes" }).click();
-      await browser!.findElement({ id: "is-accessible-yes" }).click();
+      await browser!
+        .wait(until.elementLocated({ id: "is-accessible-yes" }), 500)
+        .click();
       await browser!
         .wait(until.elementLocated({ name: "fire-exit-notes" }), 500)
         .sendKeys("Fire exit notes");
@@ -314,7 +329,9 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await expect(browser!.getCurrentUrl()).resolves.toContain("/smoke-alarm");
 
       await browser!.findElement({ id: "has-smoke-alarm-yes" }).click();
-      await browser!.findElement({ id: "is-working-yes" }).click();
+      await browser!
+        .wait(until.elementLocated({ id: "is-working-yes" }), 500)
+        .click();
       await browser!
         .wait(until.elementLocated({ name: "smoke-alarm-notes" }), 500)
         .sendKeys("Smoke alarm notes");
@@ -326,9 +343,14 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
 
       await browser!.findElement({ id: "has-metal-gates-yes" }).click();
       await browser!
-        .findElement({ id: "combustible-items-behind-gates-yes" })
+        .wait(
+          until.elementLocated({ id: "combustible-items-behind-gates-yes" }),
+          500
+        )
         .click();
-      await browser!.findElement({ id: "further-action-required-yes" }).click();
+      await browser!
+        .wait(until.elementLocated({ id: "further-action-required-yes" }), 500)
+        .click();
       await browser!
         .wait(until.elementLocated({ name: "metal-gates-notes" }), 500)
         .sendKeys("Metal gates notes");
@@ -339,7 +361,9 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await expect(browser!.getCurrentUrl()).resolves.toContain("/door-mats");
 
       await browser!.findElement({ id: "has-placed-yes" }).click();
-      await browser!.findElement({ id: "further-action-required-yes" }).click();
+      await browser!
+        .wait(until.elementLocated({ id: "further-action-required-yes" }), 500)
+        .click();
       await browser!
         .wait(until.elementLocated({ name: "door-mats-notes" }), 500)
         .sendKeys("Door mats notes");
@@ -354,7 +378,9 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await browser!
         .findElement({ id: "has-left-combustible-items-yes" })
         .click();
-      await browser!.findElement({ id: "further-action-required-yes" }).click();
+      await browser!
+        .wait(until.elementLocated({ id: "further-action-required-yes" }), 500)
+        .click();
       await browser!
         .wait(until.elementLocated({ name: "communal-areas-notes" }), 500)
         .sendKeys("Communal areas notes");
@@ -369,7 +395,10 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
       await browser!.findElement({ id: "pet-type-bird" }).click();
       await browser!.findElement({ id: "pet-type-rabbit" }).click();
       await browser!
-        .findElement({ name: "pets-permission-images" })
+        .wait(until.elementLocated({ id: "has-permission-yes" }), 500)
+        .click();
+      await browser!
+        .wait(until.elementLocated({ name: "pets-permission-images" }), 500)
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
       await browser!
         .wait(until.elementLocated({ name: "pets-notes" }), 500)
@@ -398,7 +427,7 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
         .findElement({ name: "other-comments-images" })
         .sendKeys(join(__dirname, "..", "__fixtures__", "image.jpg"));
       await browser!
-        .wait(until.elementLocated({ name: "other-comments-notes" }), 500)
+        .findElement({ name: "other-comments-notes" })
         .sendKeys("Other comments notes");
       await browser!.submit();
 

--- a/__tests__/helpers/webdriver/WebDriverWrapper.ts
+++ b/__tests__/helpers/webdriver/WebDriverWrapper.ts
@@ -3,6 +3,7 @@ import {
   Builder,
   Locator,
   WebDriver,
+  WebElementPromise,
   until
 } from "selenium-webdriver";
 import chrome from "selenium-webdriver/chrome";
@@ -110,6 +111,24 @@ class WebDriverWrapper implements WebDriver {
     const url = new URL(relativeUrl, this.baseUrl).href;
 
     return this.get(url);
+  }
+
+  waitForEnabledElement(
+    locator: Locator,
+    locateTimeout = 1000,
+    enabledTimeout = 1000
+  ): WebElementPromise {
+    const element = this.wait(
+      until.elementLocated(locator),
+      locateTimeout,
+      `Unable to find ${JSON.stringify(locator)}`
+    );
+
+    return this.wait(
+      until.elementIsEnabled(element),
+      enabledTimeout,
+      `${JSON.stringify(locator)} never became enabled`
+    );
   }
 
   async submit(

--- a/__tests__/pages/index.test.tsx
+++ b/__tests__/pages/index.test.tsx
@@ -35,7 +35,7 @@ it("redirects to /loading when online", async () => {
   });
 
   expect(routerPushMock).toHaveBeenCalledTimes(1);
-  expect(routerPushMock).toHaveBeenCalledWith("/loading");
+  expect(routerPushMock).toHaveBeenCalledWith("/loading", "/loading");
 });
 
 it("renders correctly when offline", async () => {

--- a/components/makeSubmit.tsx
+++ b/components/makeSubmit.tsx
@@ -4,6 +4,8 @@ import PropTypes from "prop-types";
 import React from "react";
 import { SubmitProps, submitPropTypes } from "remultiform/step";
 
+import isStep from "../helpers/isStep";
+
 export interface MakeSubmitProps {
   href: string;
   value: string;
@@ -18,7 +20,7 @@ export const makeSubmit = (
     return (
       <>
         {buttonProps.map(({ href, value }, i) => (
-          <Link key={i} href={href}>
+          <Link key={i} href={isStep(href) ? "/[slug]" : href} as={href}>
             <Button
               className={
                 i > 0

--- a/helpers/isStep.ts
+++ b/helpers/isStep.ts
@@ -1,0 +1,8 @@
+import steps from "../steps";
+import { hrefForSlug } from "../steps/PageSlugs";
+
+const isStep = (href: string): boolean => {
+  return Boolean(steps.find(({ step }) => hrefForSlug(step.slug) === href));
+};
+
+export default isStep;

--- a/helpers/useDatabase.ts
+++ b/helpers/useDatabase.ts
@@ -1,0 +1,21 @@
+import { createContext } from "react";
+import { Database, NamedSchema, Schema } from "remultiform/database";
+import {
+  DatabaseContext,
+  useDatabase as useRemultiformDatabase
+} from "remultiform/database-context";
+
+const useDatabase = <S extends NamedSchema<string, number, Schema>>(
+  context: DatabaseContext<S> | undefined
+): Database<S> | undefined => {
+  return useRemultiformDatabase(
+    context ||
+      // This is a bit of a hack to get around contexts being
+      // undefined on the server, while still obeying the rules of hooks.
+      ({
+        context: createContext<Database<S> | undefined>(undefined)
+      } as DatabaseContext<S>)
+  );
+};
+
+export default useDatabase;

--- a/helpers/useProcessSectionComplete.ts
+++ b/helpers/useProcessSectionComplete.ts
@@ -1,4 +1,3 @@
-import { createContext } from "react";
 import { UseAsyncReturn, useAsync } from "react-async-hook";
 import {
   Database,
@@ -6,8 +5,8 @@ import {
   StoreNames,
   StoreValue
 } from "remultiform/database";
-import { DatabaseContext, useDatabase } from "remultiform/database-context";
 
+import useDatabase from "../helpers/useDatabase";
 import ProcessDatabaseSchema, {
   ProcessRef
 } from "../storage/ProcessDatabaseSchema";
@@ -22,18 +21,12 @@ const useProcessSectionComplete = <
   boolean,
   [Database<ProcessDatabaseSchema> | undefined, string, string]
 > => {
-  const database = useDatabase(
-    Storage.ProcessContext ||
-      // This is a bit of a hack to get around contexts being
-      // undefined on the server, while still obeying the rules of hooks.
-      ({
-        context: createContext<Database<ProcessDatabaseSchema> | undefined>(
-          undefined
-        )
-      } as DatabaseContext<ProcessDatabaseSchema>)
-  );
+  const database = useDatabase(Storage.ProcessContext);
 
-  return useAsync(async () => {
+  const result = useAsync<
+    boolean,
+    [Database<ProcessDatabaseSchema> | undefined, string, string]
+  >(async () => {
     if (!database) {
       throw new Error("No database to check for process state");
     }
@@ -58,6 +51,8 @@ const useProcessSectionComplete = <
 
     return result;
   }, [database, processRef, storeNames.join(",")]);
+
+  return result;
 };
 
 export default useProcessSectionComplete;

--- a/helpers/useRedirectWhenOnline.ts
+++ b/helpers/useRedirectWhenOnline.ts
@@ -3,6 +3,7 @@ import { useAsync } from "react-async-hook";
 
 import PageSlugs, { hrefForSlug } from "../steps/PageSlugs";
 
+import isStep from "./isStep";
 import useOnlineWithRetry from "./useOnlineWithRetry";
 
 export interface UseRedirectWhenOnlineReturn {
@@ -27,7 +28,9 @@ const useRedirectWhenOnline = (
   const redirect = useAsync(
     async (result: boolean | undefined) => {
       if (result) {
-        return await router[method](hrefForSlug(slug));
+        const href = hrefForSlug(slug);
+
+        return await router[method](isStep(href) ? "/[slug]" : href, href);
       }
 
       return false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7017,7 +7017,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -7038,12 +7039,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7058,17 +7061,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7185,7 +7191,8 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7197,6 +7204,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7211,6 +7219,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -7218,12 +7227,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7242,6 +7253,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7331,7 +7343,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7343,6 +7356,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7428,7 +7442,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7464,6 +7479,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7483,6 +7499,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7526,12 +7543,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         }
@@ -12702,7 +12721,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -12720,11 +12740,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -12737,15 +12759,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -12848,7 +12873,8 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -12858,6 +12884,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -12870,17 +12897,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -12897,6 +12927,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -12977,7 +13008,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -12987,6 +13019,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -13062,7 +13095,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -13092,6 +13126,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -13109,6 +13144,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -13147,11 +13183,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -1,11 +1,11 @@
 import { NextPage, NextPageContext } from "next";
-import React, { createContext } from "react";
+import React from "react";
 import { useAsync } from "react-async-hook";
 import { Database } from "remultiform/database";
-import { DatabaseContext, useDatabase } from "remultiform/database-context";
 import { Orchestrator } from "remultiform/orchestrator";
 
 import { TenancySummary } from "../components/TenancySummary";
+import useDatabase from "../helpers/useDatabase";
 import MainLayout from "../layouts/MainLayout";
 import steps from "../steps";
 import PageSlugs from "../steps/PageSlugs";
@@ -18,16 +18,7 @@ interface Props {
 }
 
 const ProcessPage: NextPage<Props> = ({ slug }: Props) => {
-  const database = useDatabase(
-    Storage.ExternalContext ||
-      // This is a bit of a hack to get around contexts being
-      // undefined on the server, while still obeying the rules of hooks.
-      ({
-        context: createContext<Database<ExternalDatabaseSchema> | undefined>(
-          undefined
-        )
-      } as DatabaseContext<ExternalDatabaseSchema>)
-  );
+  const database = useDatabase(Storage.ExternalContext);
   const tenancyData = useAsync(
     async (db: Database<ExternalDatabaseSchema> | undefined) =>
       db?.get("tenancy", processRef),

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,10 +12,11 @@ import { DatabaseProvider } from "remultiform/database-context";
 
 import "normalize.css";
 
+import isStep from "../helpers/isStep";
 import Storage from "../storage/Storage";
 
 const Link: React.FunctionComponent<LinkComponentTypeProps> = props => (
-  <NextLink href={props.href}>
+  <NextLink href={isStep(props.href) ? "/[slug]" : props.href} as={props.href}>
     <a {...props} />
   </NextLink>
 );

--- a/pages/loading.tsx
+++ b/pages/loading.tsx
@@ -245,7 +245,7 @@ export const LoadingPage: NextPage = () => {
         </Paragraph>
       )}
 
-      <Link href={hrefForSlug(PageSlugs.VisitAttempt)}>
+      <Link href="/[slug]" as={hrefForSlug(PageSlugs.VisitAttempt)}>
         <Button disabled={!ready} data-testid="submit">
           {ready ? "Go" : "Loading..."}
         </Button>

--- a/pages/sections.tsx
+++ b/pages/sections.tsx
@@ -4,13 +4,13 @@ import {
   Paragraph
 } from "lbh-frontend-react/components";
 import { NextPage } from "next";
-import React, { createContext } from "react";
+import React from "react";
 import { useAsync } from "react-async-hook";
 import { Database } from "remultiform/database";
-import { DatabaseContext, useDatabase } from "remultiform/database-context";
 
 import { TaskList } from "../components/TaskList";
 import { TenancySummary } from "../components/TenancySummary";
+import useDatabase from "../helpers/useDatabase";
 import useProcessSectionComplete from "../helpers/useProcessSectionComplete";
 import MainLayout from "../layouts/MainLayout";
 import PageSlugs, { hrefForSlug } from "../steps/PageSlugs";
@@ -20,16 +20,7 @@ import processRef from "../storage/processRef";
 import Storage from "../storage/Storage";
 
 export const SectionsPage: NextPage = () => {
-  const database = useDatabase(
-    Storage.ExternalContext ||
-      // This is a bit of a hack to get around contexts being
-      // undefined on the server, while still obeying the rules of hooks.
-      ({
-        context: createContext<Database<ExternalDatabaseSchema> | undefined>(
-          undefined
-        )
-      } as DatabaseContext<ExternalDatabaseSchema>)
-  );
+  const database = useDatabase(Storage.ExternalContext);
   const tenancyData = useAsync(
     async (db: Database<ExternalDatabaseSchema> | undefined) =>
       db?.get("tenancy", processRef),

--- a/pages/sections.tsx
+++ b/pages/sections.tsx
@@ -87,7 +87,7 @@ export const SectionsPage: NextPage = () => {
               },
               {
                 name: "Household",
-                href: hrefForSlug(PageSlugs.Submit),
+                href: hrefForSlug(PageSlugs.Household),
                 status: idAndResidencyComplete.result ? undefined : ""
               },
               {
@@ -97,7 +97,7 @@ export const SectionsPage: NextPage = () => {
               },
               {
                 name: "Wellbeing support",
-                href: hrefForSlug(PageSlugs.Submit),
+                href: hrefForSlug(PageSlugs.HomeCheck),
                 status: idAndResidencyComplete.result ? undefined : ""
               },
               {

--- a/pages/submit.tsx
+++ b/pages/submit.tsx
@@ -9,6 +9,7 @@ import Router from "next/router";
 import React from "react";
 import { TransactionMode } from "remultiform/database";
 
+import isStep from "../helpers/isStep";
 import useOnlineWithRetry from "../helpers/useOnlineWithRetry";
 import MainLayout from "../layouts/MainLayout";
 import PageSlugs, { hrefForSlug } from "../steps/PageSlugs";
@@ -34,7 +35,9 @@ const submit = async (): Promise<void> => {
     );
   }
 
-  await Router.push(hrefForSlug(PageSlugs.Confirmed));
+  const href = hrefForSlug(PageSlugs.Confirmed);
+
+  await Router.push(isStep(href) ? "/[slug]" : href, href);
 };
 
 const SubmitPage: NextPage = () => {

--- a/steps/id-and-residency/carer.tsx
+++ b/steps/id-and-residency/carer.tsx
@@ -30,9 +30,9 @@ const step: ProcessStepDefinition = {
   heading: "Carer",
   step: {
     slug: PageSlugs.Carer,
-    nextSlug: PageSlugs.Rooms,
+    nextSlug: PageSlugs.Sections,
     Submit: makeSubmit({
-      href: hrefForSlug(PageSlugs.Rooms),
+      href: hrefForSlug(PageSlugs.Sections),
       value: "Save and continue"
     }),
     componentWrappers: [

--- a/steps/property-inspection/other-comments.tsx
+++ b/steps/property-inspection/other-comments.tsx
@@ -28,9 +28,9 @@ const step: ProcessStepDefinition = {
     "Are there any other comments or points to investigate for the property?",
   step: {
     slug: PageSlugs.OtherComments,
-    nextSlug: PageSlugs.HomeCheck,
+    nextSlug: PageSlugs.Sections,
     Submit: makeSubmit({
-      href: hrefForSlug(PageSlugs.HomeCheck),
+      href: hrefForSlug(PageSlugs.Sections),
       value: "Save and continue"
     }),
     componentWrappers: [

--- a/steps/wellbeing-support/home-check.tsx
+++ b/steps/wellbeing-support/home-check.tsx
@@ -23,9 +23,9 @@ const step: ProcessStepDefinition = {
     "Are you doing a Home Check as part of the Tenancy and Household Check?",
   step: {
     slug: PageSlugs.HomeCheck,
-    nextSlug: PageSlugs.Submit,
+    nextSlug: PageSlugs.Sections,
     Submit: makeSubmit({
-      href: hrefForSlug(PageSlugs.Submit),
+      href: hrefForSlug(PageSlugs.Sections),
       value: "Save and continue"
     }),
     componentWrappers: [


### PR DESCRIPTION
We were interacting with disabled elements. We need to wait for `remultiform` to finish fetching from the offline storage, and enable the elements before interacting with them, or no data will ever be stored.