### PR TITLE
Inject the base path during builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
 
       - run:
           name: Build Docker image
-          command: docker build .
+          command: docker build --build-arg $BASE_PATH .
 
   deploy:
     parameters:
@@ -109,6 +109,7 @@ workflows:
           account-url: AWS_ECR_HOST
           aws-access-key-id: AWS_ACCESS_KEY_ID
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          extra-build-args: --build-arg $BASE_PATH
           region: AWS_REGION
           repo: $AWS_ECR_PATH_DEV
           tag: $CIRCLE_SHA1

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,10 @@ RUN apk add --no-cache bash
 
 WORKDIR /app
 
+ARG BASE_PATH
+
 ENV NODE_ENV production
+ENV BASE_PATH ${BASE_PATH}
 
 # ------------------------------------------------------------------------------
 # dependencies


### PR DESCRIPTION
We need to build the `BASE_PATH` in during the build. The remaining environment variables are only needed at runtime or during development.