### PR TITLE
Ask Dependabot to automerge all minor updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -22,8 +22,5 @@ update_configs:
     automerged_updates:
       - match:
           dependency_type: all
-          update_type: semver:patch
-      - match:
-          dependency_name: "@babel/*"
           update_type: semver:minor
     version_requirement_updates: increase_versions


### PR DESCRIPTION
There are a lot of dependencies, and having to manually keep up with them is irritating. Instead, we should rely on CI and smoke testing before deployments to catch any issues, and save the cognitive load on staying up to date.