### PR TITLE
MT3-392 #ready-for-test Don't display former tenants

### DIFF
--- a/__tests__/pages/loading.test.tsx
+++ b/__tests__/pages/loading.test.tsx
@@ -121,25 +121,29 @@ it("renders correctly when online", async () => {
               fullAddressDisplay:
                 "FLAT 1\r\n1 TEST STREET\r\nTEST TOWN TT1 1TT",
               responsible: true,
-              fullName: "TestTenant1"
+              fullName: "TestTenant1",
+              larn: "LARN94105032"
             },
             {
               fullAddressDisplay:
                 "FLAT 1\r\n1 TEST STREET\r\nTEST TOWN TT1 1TT",
               responsible: true,
-              fullName: "TestTenant2"
+              fullName: "TestTenant2",
+              larn: null
             },
             {
               fullAddressDisplay:
                 "FLAT 1\r\n1 TEST STREET\r\nTEST TOWN TT1 1TT",
               responsible: false,
-              fullName: "TestHouseholdMember1"
+              fullName: "TestHouseholdMember1",
+              larn: null
             },
             {
               fullAddressDisplay:
                 "FLAT 1\r\n1 TEST STREET\r\nTEST TOWN TT1 1TT",
               responsible: false,
-              fullName: "TestHouseholdMember2"
+              fullName: "TestHouseholdMember2",
+              larn: null
             }
           ]
         };
@@ -270,7 +274,7 @@ it("renders correctly when online", async () => {
               <dd
                 className="govuk-summary-list__value lbh-summary-list__value"
               >
-                TestTenant1, TestTenant2
+                TestTenant1
               </dd>
             </div>
             <div

--- a/pages/loading.tsx
+++ b/pages/loading.tsx
@@ -290,6 +290,7 @@ const useFetchResidentData = (): UseApiWithStorageReturn<
         responsible: boolean;
         fullAddressDisplay: string;
         dateOfBirth: string;
+        larn: string;
       }[];
     }) {
       const fullAddress = data.results[0].fullAddressDisplay;
@@ -310,7 +311,7 @@ const useFetchResidentData = (): UseApiWithStorageReturn<
       address.push(...cityAndPostcode);
 
       const tenants = data.results
-        .filter(contact => contact.responsible)
+        .filter(contact => contact.responsible && contact.larn)
         .map(contact => ({
           id: contact.contactId,
           fullName: contact.fullName,


### PR DESCRIPTION
Previous tenants were being displayed on "Who is present for this check?". As far as I can tell, current tenants have a non-null `larn`value, but if anyone has more knowledge about this, please let me know.

https://hackney.atlassian.net/browse/MT3-392