### PR TITLE
MT3-410

### DIFF
--- a/steps/property-inspection/garden.tsx
+++ b/steps/property-inspection/garden.tsx
@@ -6,15 +6,12 @@ import {
   ComponentWrapper,
   DynamicComponent
 } from "remultiform/component-wrapper";
-
 import { ImageInput } from "../../components/ImageInput";
 import { makeSubmit } from "../../components/makeSubmit";
 import { RadioButtons } from "../../components/RadioButtons";
 import { TextArea } from "../../components/TextArea";
-
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
 import processRef from "../../storage/processRef";
-
 import PageSlugs, { urlObjectForSlug } from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -128,7 +125,10 @@ const step = {
           renderWhen(stepValues: {
             "garden-type"?: ComponentValue<ProcessDatabaseSchema, "property">;
           }): boolean {
-            return stepValues["garden-type"] === ("private" || "not sure");
+            return (
+              stepValues["garden-type"] === "private" ||
+              stepValues["garden-type"] === "not sure"
+            );
           },
           defaultValue: "",
           emptyValue: "",

--- a/steps/property-inspection/garden.tsx
+++ b/steps/property-inspection/garden.tsx
@@ -178,14 +178,14 @@ const step = {
           Component: TextArea,
           props: {
             label: {
-              value: "Add note about upkeep of garden if necessary."
+              value: "Add note about garden if necessary."
             } as { id?: string; value: React.ReactNode },
             name: "garden-notes"
           },
           renderWhen(stepValues: {
-            "is-maintained"?: ComponentValue<ProcessDatabaseSchema, "property">;
+            "has-garden"?: ComponentValue<ProcessDatabaseSchema, "property">;
           }): boolean {
-            return stepValues["is-maintained"] === "yes";
+            return stepValues["has-garden"] === "yes";
           },
           defaultValue: "",
           emptyValue: "",


### PR DESCRIPTION

Added the is maintained radio buttons if the choice is "not -sure" for garden type. Also added notes box if the garden is not maintained.
The notes box is already there if the choice is maintained but appears below the take photo button. May need to play around with the positioning of these as wasn't sure how to implement && or || without repeating a renderWhen for the no condition.

<!--
  Is this related to a ticket in Jira? If so, add Smart Commit commands to the
  PR title to be automatically included in the merge commit if the PR is merged.







