### PR TITLE
MT3-594 #ready-for-test Migrate resident data correctly and clear removed data

### DIFF
--- a/__tests__/helpers/createTestProcess.ts
+++ b/__tests__/helpers/createTestProcess.ts
@@ -1,4 +1,5 @@
 import uuid from "uuid/v1";
+import databaseSchemaVersion from "../../storage/databaseSchemaVersion";
 
 export default async (ref = uuid()): Promise<void> => {
   process.env.TEST_PROCESS_REF = ref;
@@ -10,7 +11,7 @@ export default async (ref = uuid()): Promise<void> => {
       value: parseInt(process.env.PROCESS_TYPE_VALUE!),
       name: process.env.PROCESS_TYPE_NAME
     },
-    processDataSchemaVersion: 4
+    processDataSchemaVersion: databaseSchemaVersion
   });
 
   const response = await fetch(

--- a/__tests__/pages/thc/[processRef]/loading.test.tsx
+++ b/__tests__/pages/thc/[processRef]/loading.test.tsx
@@ -3,11 +3,14 @@ import React from "react";
 import { act, create, ReactTestRenderer } from "react-test-renderer";
 import LoadingPage from "../../../../pages/thc/[processRef]/loading";
 import databaseSchemaVersion from "../../../../storage/databaseSchemaVersion";
+import { processStoreNames } from "../../../../storage/ProcessDatabaseSchema";
 import Storage from "../../../../storage/Storage";
 import { promiseToWaitForNextTick } from "../../../helpers/promise";
 import { spyOnConsoleError } from "../../../helpers/spies";
 
 const originalExternalContext = Storage.ExternalContext;
+const originalProcessContext = Storage.ProcessContext;
+const originalResidentContext = Storage.ResidentContext;
 
 beforeEach(() => {
   sessionStorage.setItem("currentProcessRef", "test-process-ref");
@@ -31,21 +34,27 @@ beforeEach(() => {
     database: {
       ...jest.fn()(),
       db: { version: databaseSchemaVersion },
+      get: (): undefined => undefined,
       put: jest.fn(),
       transaction: async (_, tx): Promise<void> => {
-        await tx({
-          ...jest.fn()(),
-          lastModified: {
-            ...jest.fn()(),
-            get: (): undefined => undefined,
-            put: jest.fn()
-          },
-          property: {
-            ...jest.fn()(),
-            put: jest.fn()
-          }
-        });
+        await tx(
+          processStoreNames.reduce(
+            (stores, storeName) => ({
+              ...stores,
+              [storeName]: { ...jest.fn()(), put: jest.fn(), delete: jest.fn() }
+            }),
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            {} as any
+          )
+        );
       }
+    }
+  };
+  Storage.ResidentContext = {
+    ...jest.fn()(),
+    database: {
+      ...jest.fn()(),
+      db: { version: databaseSchemaVersion }
     }
   };
 
@@ -59,6 +68,8 @@ afterEach(() => {
   sessionStorage.clear();
 
   Storage.ExternalContext = originalExternalContext;
+  Storage.ProcessContext = originalProcessContext;
+  Storage.ResidentContext = originalResidentContext;
 });
 
 it("renders correctly when online", async () => {

--- a/__tests__/pages/thc/[processRef]/loading.test.tsx
+++ b/__tests__/pages/thc/[processRef]/loading.test.tsx
@@ -2,6 +2,7 @@ import * as router from "next/router";
 import React from "react";
 import { act, create, ReactTestRenderer } from "react-test-renderer";
 import LoadingPage from "../../../../pages/thc/[processRef]/loading";
+import databaseSchemaVersion from "../../../../storage/databaseSchemaVersion";
 import Storage from "../../../../storage/Storage";
 import { promiseToWaitForNextTick } from "../../../helpers/promise";
 import { spyOnConsoleError } from "../../../helpers/spies";
@@ -29,7 +30,7 @@ beforeEach(() => {
     ...jest.fn()(),
     database: {
       ...jest.fn()(),
-      db: { version: 4 },
+      db: { version: databaseSchemaVersion },
       put: jest.fn(),
       transaction: async (_, tx): Promise<void> => {
         await tx({

--- a/storage/ProcessDatabaseSchema.ts
+++ b/storage/ProcessDatabaseSchema.ts
@@ -1,6 +1,6 @@
 import { NamedSchema, StoreNames } from "remultiform/database";
 import { DeepPartial } from "utility-types";
-
+import databaseSchemaVersion from "./databaseSchemaVersion";
 import ResidentDatabaseSchema, { ResidentRef } from "./ResidentDatabaseSchema";
 
 export type ProcessRef = string;
@@ -11,7 +11,7 @@ export const processDatabaseName = `mat-process-${
 
 type ProcessDatabaseSchema = NamedSchema<
   typeof processDatabaseName,
-  4,
+  typeof databaseSchemaVersion,
   {
     lastModified: {
       key: ProcessRef;

--- a/storage/ResidentDatabaseSchema.ts
+++ b/storage/ResidentDatabaseSchema.ts
@@ -1,4 +1,5 @@
 import { NamedSchema, StoreNames } from "remultiform/database";
+import databaseSchemaVersion from "./databaseSchemaVersion";
 
 export type ResidentRef = string;
 
@@ -8,7 +9,7 @@ export const residentDatabaseName = `mat-process-${
 
 type ResidentDatabaseSchema = NamedSchema<
   typeof residentDatabaseName,
-  2,
+  typeof databaseSchemaVersion,
   {
     id: {
       key: ResidentRef;

--- a/storage/Storage.ts
+++ b/storage/Storage.ts
@@ -7,6 +7,7 @@ import {
 } from "remultiform/database";
 import { DatabaseContext } from "remultiform/database-context";
 import uuid from "uuid/v5";
+import databaseSchemaVersion from "./databaseSchemaVersion";
 import ExternalDatabaseSchema, {
   externalDatabaseName
 } from "./ExternalDatabaseSchema";
@@ -98,7 +99,7 @@ export default class Storage {
 
     const processDatabasePromise = Database.open<ProcessDatabaseSchema>(
       processDatabaseName,
-      4,
+      databaseSchemaVersion,
       {
         upgrade(upgrade) {
           let version = upgrade.oldVersion;
@@ -147,7 +148,7 @@ export default class Storage {
 
     const residentDatabasePromise = Database.open<ResidentDatabaseSchema>(
       residentDatabaseName,
-      2,
+      databaseSchemaVersion,
       {
         upgrade(upgrade) {
           let version = upgrade.oldVersion;
@@ -166,6 +167,10 @@ export default class Storage {
             upgrade.createStore("signature");
 
             version = 2;
+          }
+
+          if (version < 4) {
+            version = 4;
           }
 
           if (version !== upgrade.newVersion) {

--- a/storage/Storage.ts
+++ b/storage/Storage.ts
@@ -1,10 +1,4 @@
-import {
-  Database,
-  Store,
-  StoreNames,
-  StoreValue,
-  TransactionMode
-} from "remultiform/database";
+import { Database, StoreValue, TransactionMode } from "remultiform/database";
 import { DatabaseContext } from "remultiform/database-context";
 import uuid from "uuid/v5";
 import databaseSchemaVersion from "./databaseSchemaVersion";
@@ -352,58 +346,116 @@ export default class Storage {
     }
 
     if (!this.ProcessContext || !this.ProcessContext.database) {
-      throw new Error("No database to update");
+      throw new Error("No process database to update");
     }
 
-    const db = await this.ProcessContext.database;
+    if (!this.ResidentContext || !this.ResidentContext.database) {
+      throw new Error("No resident database to update");
+    }
+
+    const processDatabase = await this.ProcessContext.database;
+    const residentDatabase = await this.ResidentContext.database;
+
+    if (
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (processDatabase as any).db.version !==
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (residentDatabase as any).db.version
+    ) {
+      throw new Error("Process and resident database versions must match");
+    }
+
+    // Ideally we'd be exposing the version on the databases directly, but
+    // this hack works for now.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const schemaVersion = (processDatabase as any).db.version;
 
     const migratedProcessData = await migrateProcessData(
       processData,
       dataSchemaVersion || 0,
-      // Ideally we'd be exposing the version on the database directly, but
-      // this hack works for now.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (db as any).db.version
+      schemaVersion
     );
 
-    let isNewer = false;
+    const lastModified = new Date(dateLastModified || dateCreated);
 
-    await db.transaction(
-      processStoreNames,
-      async stores => {
-        const lastModified = new Date(dateLastModified || dateCreated);
+    const isNewer = await this.isProcessNewerThanStorage(
+      processRef,
+      lastModified
+    );
 
-        isNewer = await this.isProcessNewerThanStorage(
-          stores.lastModified,
-          processRef,
-          lastModified
-        );
+    if (isNewer) {
+      const realProcessStoreNames = processStoreNames.filter(
+        storeName => storeName !== "lastModified"
+      );
 
-        if (!isNewer) {
-          return;
-        }
+      await processDatabase.transaction(
+        realProcessStoreNames,
+        async stores => {
+          await Promise.all([
+            ...realProcessStoreNames.map(async storeName => {
+              const store = stores[storeName];
+              const value = migratedProcessData[storeName];
 
-        await Promise.all(
-          Object.entries(migratedProcessData).map(
-            async ([storeName, value]) => {
-              if (storeName === "lastModified") {
-                return;
+              if (value === undefined) {
+                await store.delete(processRef);
+              } else {
+                await store.put(
+                  processRef,
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  value as any
+                );
               }
+            })
+          ]);
+        },
+        TransactionMode.ReadWrite
+      );
 
-              await stores[
-                storeName as StoreNames<ProcessDatabaseSchema["schema"]>
-              ].put(
-                processRef,
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                value as any
-              );
-            }
-          )
+      const residentRefs = migratedProcessData.tenantsPresent;
+      const migratedResidentData = migratedProcessData.residents;
+
+      if (migratedResidentData && residentRefs && residentRefs.length > 0) {
+        await residentDatabase.transaction(
+          residentStoreNames,
+          async stores => {
+            await Promise.all([
+              ...residentStoreNames.map(async storeName => {
+                const store = stores[storeName];
+
+                await Promise.all(
+                  residentRefs.map(async residentRef => {
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    const ref = residentRef!;
+                    const allValues = migratedResidentData[ref];
+                    const value =
+                      allValues === undefined
+                        ? undefined
+                        : allValues[storeName];
+
+                    if (value === undefined) {
+                      await store.delete(ref);
+                    } else {
+                      await store.put(
+                        ref,
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        value as any
+                      );
+                    }
+                  })
+                );
+              })
+            ]);
+          },
+          TransactionMode.ReadWrite
         );
+      }
+    }
 
-        await stores.lastModified.put(processRef, lastModified.toISOString());
-      },
-      TransactionMode.ReadWrite
+    // Do this last so if anything goes wrong, we can try again.
+    await processDatabase.put(
+      "lastModified",
+      processRef,
+      lastModified.toISOString()
     );
 
     return isNewer;
@@ -424,16 +476,19 @@ export default class Storage {
   }
 
   static async isProcessNewerThanStorage(
-    store: Store<
-      ProcessDatabaseSchema["schema"],
-      StoreNames<ProcessDatabaseSchema["schema"]>[],
-      "lastModified"
-    >,
     processRef: string,
     lastModified: Date
   ): Promise<boolean> {
-    const storedLastModified = await store.get(processRef);
+    if (!this.ProcessContext) {
+      return false;
+    }
 
-    return !storedLastModified || lastModified > new Date(storedLastModified);
+    const db = await this.ProcessContext.database;
+
+    const storedLastModified = await db.get("lastModified", processRef);
+
+    return storedLastModified === undefined
+      ? true
+      : lastModified > new Date(storedLastModified);
   }
 }

--- a/storage/databaseSchemaVersion.ts
+++ b/storage/databaseSchemaVersion.ts
@@ -1,0 +1,1 @@
+export default 4;


### PR DESCRIPTION
This makes the following changes:

We now lock the data schema version for resident data to the process data schema. The database only knows about one data schema, and locking them saves the hassle of working out how to track and validate an arbitrary number of nested schemas.

We now migrate the data for residents alongside the rest of the process data. Before it would throw an error if there was resident data to import.

We now remove data that doesn't exist in the incoming data from the local store. We don't want it sneaking back in.