### PR TITLE
MT3-481 #ready-to-test Set up production pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ workflows:
           service-name: $AWS_SERVICE_DEV
           image-tag: $CIRCLE_SHA1
 
-  check-and-deploy-to-production:
+  check-and-deploy-to-staging:
     jobs:
       - install-and-test:
           name: install-and-test-master
@@ -130,20 +130,20 @@ workflows:
               only: master
 
       - aws-ecr/build-and-push-image:
-          name: build-and-push-to-production
+          name: build-and-push-to-staging
           requires:
             - install-and-test-master
           account-url: AWS_ECR_HOST
           aws-access-key-id: AWS_ACCESS_KEY_ID
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY
           region: AWS_REGION
-          repo: $AWS_ECR_PATH_PROD
+          repo: $AWS_ECR_PATH_STAGING
           tag: $CIRCLE_SHA1
 
       - deploy:
-          name: deploy-to-production
+          name: deploy-to-staging
           requires:
-            - build-and-push-to-production
-          cluster-name: $AWS_CLUSTER_PROD
-          service-name: $AWS_SERVICE_PROD
+            - build-and-push-to-staging
+          cluster-name: $AWS_CLUSTER_STAGING
+          service-name: $AWS_SERVICE_STAGING
           image-tag: $CIRCLE_SHA1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,3 +120,30 @@ workflows:
           cluster-name: $AWS_CLUSTER_DEV
           service-name: $AWS_SERVICE_DEV
           image-tag: $CIRCLE_SHA1
+
+  check-and-deploy-to-production:
+    jobs:
+      - install-and-test:
+          name: install-and-test-master
+          filters:
+            branches:
+              only: master
+
+      - aws-ecr/build-and-push-image:
+          name: build-and-push-to-production
+          requires:
+            - install-and-test-master
+          account-url: AWS_ECR_HOST
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          region: AWS_REGION
+          repo: $AWS_ECR_PATH_PROD
+          tag: $CIRCLE_SHA1
+
+      - deploy:
+          name: deploy-to-production
+          requires:
+            - build-and-push-to-production
+          cluster-name: $AWS_CLUSTER_PROD
+          service-name: $AWS_SERVICE_PROD
+          image-tag: $CIRCLE_SHA1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,15 +97,15 @@ workflows:
   check-and-deploy-to-development:
     jobs:
       - install-and-test:
-          name: install-and-test-master
+          name: install-and-test-development
           filters:
             branches:
-              only: master
+              only: development
 
       - aws-ecr/build-and-push-image:
           name: build-and-push-to-development
           requires:
-            - install-and-test-master
+            - install-and-test-development
           account-url: AWS_ECR_HOST
           aws-access-key-id: AWS_ACCESS_KEY_ID
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
Before this can be merged, we need to switch to using the `development` branch directly, and add environment variables to CircleCI.

I don't know by what heuristic we want to deploy things to `staging`. So I've left that out. I sort of think that there's not a huge amount of value of having `staging` and `development` environments, given the way we work, and we could make these services cheaper to run by dropping one. All work pushed to the `development` branch should be considered safe to deploy, so that should probably go straight to `staging`. Thoughts @LBHTKarki?