### PR TITLE
Mt3 398 other support

### DIFF
--- a/__tests__/features/end-to-end.steps.ts
+++ b/__tests__/features/end-to-end.steps.ts
@@ -311,6 +311,11 @@ const processData = {
           isPostVisitAction: false
         }
       },
+      otherSupport: {
+        fullName: "Other support name",
+        role: "other support role",
+        phoneNumber: "0123455789"
+      },
       signature: ""
     }
   }
@@ -615,6 +620,30 @@ defineFeature(loadFeature("./end-to-end.feature"), test => {
           name: "carer-notes"
         })
       ).sendKeys(processData.residents[presentTenantRef].carer.notes.value);
+
+      await browser!.submit();
+      //Other support page
+      await expect(browser!.getCurrentUrl()).resolves.toContain(
+        `/other-support/${presentTenantRef}`
+      );
+
+      (
+        await browser!.waitForEnabledElement({
+          name: "other-support-full-name"
+        })
+      ).sendKeys(processData.residents[presentTenantRef].otherSupport.fullName);
+      (
+        await browser!.waitForEnabledElement({
+          name: "other-support-role"
+        })
+      ).sendKeys(processData.residents[presentTenantRef].otherSupport.role);
+      (
+        await browser!.waitForEnabledElement({
+          name: "other-support-phone-number"
+        })
+      ).sendKeys(
+        processData.residents[presentTenantRef].otherSupport.phoneNumber
+      );
 
       await browser!.submit();
 

--- a/steps/id-and-residency/carer.tsx
+++ b/steps/id-and-residency/carer.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../components/TextAreaDetails";
 import { TextInput } from "../../components/TextInput";
 import keyFromSlug from "../../helpers/keyFromSlug";
+import nextSlugWithId from "../../helpers/nextSlugWithId";
 import ProcessStepDefinition from "../../helpers/ProcessStepDefinition";
 import yesNoRadios from "../../helpers/yesNoRadios";
 import { Note } from "../../storage/DatabaseSchema";
@@ -135,7 +136,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "carer"> = {
   },
   step: {
     slug: PageSlugs.Carer,
-    nextSlug: PageSlugs.Verify,
+    nextSlug: nextSlugWithId(PageSlugs.OtherSupport),
     submit: (nextSlug?: string): ReturnType<typeof makeSubmit> =>
       makeSubmit({
         slug: nextSlug as PageSlugs | undefined,

--- a/steps/id-and-residency/index.ts
+++ b/steps/id-and-residency/index.ts
@@ -1,12 +1,12 @@
 import ProcessStepDefinition from "../../helpers/ProcessStepDefinition";
 import ResidentDatabaseSchema from "../../storage/ResidentDatabaseSchema";
-
-import presentToCheck from "./present-for-check";
+import carer from "./carer";
 import id from "./id";
+import nextOfKin from "./next-of-kin";
+import otherSupport from "./other-support";
+import presentToCheck from "./present-for-check";
 import residency from "./residency";
 import tenantPhoto from "./tenant-photo";
-import nextOfKin from "./next-of-kin";
-import carer from "./carer";
 
 export type IdAndResidencyProcessStoreNames = "tenantsPresent";
 
@@ -17,7 +17,8 @@ export type IdAndResidencyResidentStoreNames =
   | "residency"
   | "photo"
   | "nextOfKin"
-  | "carer";
+  | "carer"
+  | "otherSupport";
 
 export const idAndResidencyResidentSteps = [
   id as ProcessStepDefinition<
@@ -37,6 +38,10 @@ export const idAndResidencyResidentSteps = [
     IdAndResidencyResidentStoreNames
   >,
   carer as ProcessStepDefinition<
+    ResidentDatabaseSchema,
+    IdAndResidencyResidentStoreNames
+  >,
+  otherSupport as ProcessStepDefinition<
     ResidentDatabaseSchema,
     IdAndResidencyResidentStoreNames
   >

--- a/steps/id-and-residency/other-support.ts
+++ b/steps/id-and-residency/other-support.ts
@@ -1,0 +1,132 @@
+import { Heading, HeadingLevels } from "lbh-frontend-react";
+import {
+  ComponentDatabaseMap,
+  ComponentWrapper,
+  DynamicComponent,
+  StaticComponent
+} from "remultiform/component-wrapper";
+import { makeSubmit } from "../../components/makeSubmit";
+import { TextInput } from "../../components/TextInput";
+import keyFromSlug from "../../helpers/keyFromSlug";
+import ProcessStepDefinition from "../../helpers/ProcessStepDefinition";
+import ResidentDatabaseSchema from "../../storage/ResidentDatabaseSchema";
+import Storage from "../../storage/Storage";
+import PageSlugs from "../PageSlugs";
+import PageTitles from "../PageTitles";
+
+const questions = {
+  "other-support-details": "Other support details"
+};
+
+const step: ProcessStepDefinition<ResidentDatabaseSchema, "otherSupport"> = {
+  title: PageTitles.OtherSupport,
+  heading: "Other Support",
+  context: Storage.ResidentContext,
+  review: {
+    rows: [
+      {
+        label: questions["other-support-details"],
+        values: {
+          "other-support-full-name": {
+            renderValue(name: string): React.ReactNode {
+              return name;
+            }
+          },
+          "other-support-role": {
+            renderValue(role: string): React.ReactNode {
+              return role;
+            }
+          },
+          "other-support-phone-number": {
+            renderValue(phoneNumber: string): React.ReactNode {
+              return phoneNumber;
+            }
+          }
+        }
+      }
+    ]
+  },
+  step: {
+    slug: PageSlugs.OtherSupport,
+    nextSlug: PageSlugs.Verify,
+    submit: (nextSlug?: string): ReturnType<typeof makeSubmit> =>
+      makeSubmit({
+        slug: nextSlug as PageSlugs | undefined,
+        value: "Save and continue"
+      }),
+    componentWrappers: [
+      ComponentWrapper.wrapStatic<ResidentDatabaseSchema, "otherSupport">(
+        new StaticComponent({
+          key: "other-support-heading",
+          Component: Heading,
+          props: {
+            level: HeadingLevels.H2,
+            children: questions["other-support-details"]
+          }
+        })
+      ),
+      ComponentWrapper.wrapDynamic(
+        new DynamicComponent({
+          key: "other-support-full-name",
+          Component: TextInput,
+          props: {
+            name: "other-support-full-name",
+            label: "Full name"
+          },
+          defaultValue: "",
+          emptyValue: "",
+          databaseMap: new ComponentDatabaseMap<
+            ResidentDatabaseSchema,
+            "otherSupport"
+          >({
+            storeName: "otherSupport",
+            key: keyFromSlug(),
+            property: ["fullName"]
+          })
+        })
+      ),
+      ComponentWrapper.wrapDynamic(
+        new DynamicComponent({
+          key: "other-support-role",
+          Component: TextInput,
+          props: {
+            name: "other-support-role",
+            label: "Role (e.g. support worker, social worker, doctor)"
+          },
+          defaultValue: "",
+          emptyValue: "",
+          databaseMap: new ComponentDatabaseMap<
+            ResidentDatabaseSchema,
+            "otherSupport"
+          >({
+            storeName: "otherSupport",
+            key: keyFromSlug(),
+            property: ["role"]
+          })
+        })
+      ),
+      ComponentWrapper.wrapDynamic(
+        new DynamicComponent({
+          key: "other-support-phone-number",
+          Component: TextInput,
+          props: {
+            name: "other-support-phone-number",
+            label: "Phone number"
+          },
+          defaultValue: "",
+          emptyValue: "",
+          databaseMap: new ComponentDatabaseMap<
+            ResidentDatabaseSchema,
+            "otherSupport"
+          >({
+            storeName: "otherSupport",
+            key: keyFromSlug(),
+            property: ["phoneNumber"]
+          })
+        })
+      )
+    ]
+  }
+};
+
+export default step;

--- a/steps/id-and-residency/present-for-check.tsx
+++ b/steps/id-and-residency/present-for-check.tsx
@@ -35,6 +35,7 @@ const TenantsSelect: React.FunctionComponent<Omit<
   return (
     <Checkboxes
       {...props}
+      required={true}
       checkboxes={
         tenants.result
           ? tenants.result.map(tenant => ({

--- a/steps/id-and-residency/present-for-check.tsx
+++ b/steps/id-and-residency/present-for-check.tsx
@@ -35,7 +35,7 @@ const TenantsSelect: React.FunctionComponent<Omit<
   return (
     <Checkboxes
       {...props}
-      required={true}
+      required
       checkboxes={
         tenants.result
           ? tenants.result.map(tenant => ({

--- a/storage/ResidentDatabaseSchema.ts
+++ b/storage/ResidentDatabaseSchema.ts
@@ -66,6 +66,15 @@ type ResidentDatabaseSchema = NamedSchema<
       };
     };
 
+    otherSupport: {
+      key: ResidentRef;
+      value: {
+        fullName: string;
+        role: string;
+        phoneNumber: string;
+      };
+    };
+
     signature: {
       key: ResidentRef;
       value: string;
@@ -81,6 +90,7 @@ const storeNames: {
   photo: true,
   nextOfKin: true,
   carer: true,
+  otherSupport: true,
   signature: true
 };
 

--- a/storage/Storage.ts
+++ b/storage/Storage.ts
@@ -223,6 +223,12 @@ export default class Storage {
             version = 2;
           }
 
+          if (version === 2) {
+            upgrade.createStore("otherSupport");
+
+            version = 3;
+          }
+
           if (version < 5) {
             version = 5;
           }


### PR DESCRIPTION
This page is ready without the 'add another' feature. Currently the next page is the Verify page. I'm not sure if this will need to be changed as what shows on balsamiq is a slightly different varify page. 
<!--
  Is this related to a ticket in Jira? If so, add Smart Commit commands to the
  PR title to be automatically included in the merge commit if the PR is merged.

  For example:

  MT3-221 #ready-for-test #comment Create a pull request template

  https://confluence.atlassian.com/fisheye/using-smart-commits-960155400.html
  -->

# What?

<!--
  What new features or changes does this pull request contain?

  Include before and after screenshots, if appropriate.
  -->

# Why?

<!--
  What motivates these changes?

  Include any user stories driving this feature, if appropriate.
  -->

# Notes

<!--
  Is there anything about the implementation worth calling out to reviewers?
  -->

# Next steps

<!--
  Is there any follow up work that needs to be done?

  Consider using a checklist, for example:

  - [ ] do something
  - [ ] do something else
  -->
