### PR TITLE
Switch to parsing the process ref from the URL

### DIFF
--- a/helpers/idFromSlug.ts
+++ b/helpers/idFromSlug.ts
@@ -4,9 +4,9 @@ import unprefixUrl from "./unprefixUrl";
 const idFromSlug = (
   router: NextRouter,
   slug: string | string[] | undefined
-): string => {
+): string | undefined => {
   if (!slug || typeof slug === "string") {
-    throw new Error("No ID in slug");
+    return;
   }
 
   const slugParts = unprefixUrl(router, {
@@ -16,7 +16,7 @@ const idFromSlug = (
     .slice(1);
 
   if (slugParts.length < 2) {
-    throw new Error("No ID in slug");
+    return;
   }
 
   return slugParts[slugParts.length - 1];

--- a/helpers/keyFromSlug.ts
+++ b/helpers/keyFromSlug.ts
@@ -1,15 +1,32 @@
 import router from "next/router";
+import getProcessRef from "./getProcessRef";
 import idFromSlug from "./idFromSlug";
 import isServer from "./isServer";
 
-const keyFromSlug = (): (() => string) => (): string => {
+const keyFromSlug = (expectId = false): (() => string) => (): string => {
   if (isServer) {
     return "";
   }
 
   // `router.query` might be an empty object when first loading a page for
   // some reason.
-  return idFromSlug(router, router.query.slug);
+  const slug = router.query.slug;
+
+  const id = idFromSlug(router, slug);
+
+  if (id) {
+    return id;
+  } else if (expectId) {
+    throw new Error("No ID found in the slug");
+  }
+
+  const processRef = getProcessRef(router);
+
+  if (processRef) {
+    return processRef;
+  }
+
+  throw new Error("No key found in the slug");
 };
 
 export default keyFromSlug;

--- a/pages/thc/[processRef]/[...slug].tsx
+++ b/pages/thc/[processRef]/[...slug].tsx
@@ -13,7 +13,6 @@ import useDataValue from "../../../helpers/useDataValue";
 import MainLayout from "../../../layouts/MainLayout";
 import steps from "../../../steps";
 import ProcessDatabaseSchema from "../../../storage/ProcessDatabaseSchema";
-import tmpProcessRef from "../../../storage/processRef";
 import ResidentDatabaseSchema from "../../../storage/ResidentDatabaseSchema";
 import Storage from "../../../storage/Storage";
 
@@ -118,7 +117,11 @@ const ProcessPage: NextPage = () => {
         provideDatabase={false}
         onNextStep={async (): Promise<void> => {
           try {
-            await Storage.updateProcessLastModified(tmpProcessRef);
+            if (!processRef) {
+              throw new Error("No process to reference");
+            }
+
+            await Storage.updateProcessLastModified(processRef);
           } catch (error) {
             // This is invisible to the user, so we should do something to
             // display it to them.

--- a/pages/thc/[processRef]/loading.tsx
+++ b/pages/thc/[processRef]/loading.tsx
@@ -29,7 +29,6 @@ import PageSlugs, { urlObjectForSlug } from "../../../steps/PageSlugs";
 import PageTitles from "../../../steps/PageTitles";
 import ExternalDatabaseSchema from "../../../storage/ExternalDatabaseSchema";
 import { ProcessJson } from "../../../storage/ProcessDatabaseSchema";
-import tmpProcessRef from "../../../storage/processRef";
 import { ResidentRef } from "../../../storage/ResidentDatabaseSchema";
 import Storage from "../../../storage/Storage";
 
@@ -253,7 +252,7 @@ const useFetchAndStoreProcessJson = (): {
     // The steps still use the hardcoded `processRef`, so we need to also use
     // it, even though we're using the correct value to fetch from the
     // backend.
-    return Storage.updateProcessData(tmpProcessRef, processJson.result);
+    return Storage.updateProcessData(processRef, processJson.result);
   }, [
     processRef,
     processJson.loading,

--- a/pages/thc/[processRef]/sections.tsx
+++ b/pages/thc/[processRef]/sections.tsx
@@ -10,7 +10,6 @@ import useValidateData from "../../../helpers/useValidateData";
 import MainLayout from "../../../layouts/MainLayout";
 import PageSlugs, { urlObjectForSlug } from "../../../steps/PageSlugs";
 import PageTitles from "../../../steps/PageTitles";
-import tmpProcessRef from "../../../storage/processRef";
 import Storage from "../../../storage/Storage";
 
 export const SectionsPage: NextPage = () => {
@@ -33,7 +32,7 @@ export const SectionsPage: NextPage = () => {
   const idAndResidencyStarted = useValidateData(
     Storage.ProcessContext,
     ["tenantsPresent"],
-    tmpProcessRef
+    processRef
   );
   const idAndResidencyComplete = useValidateData(
     Storage.ResidentContext,
@@ -43,15 +42,15 @@ export const SectionsPage: NextPage = () => {
   const householdStarted = useValidateData(
     Storage.ProcessContext,
     ["household"],
-    tmpProcessRef,
+    processRef,
     valueSets => {
       const householdSet = valueSets.household;
 
-      if (householdSet === undefined) {
+      if (householdSet === undefined || processRef === undefined) {
         return false;
       }
 
-      const household = householdSet[tmpProcessRef];
+      const household = householdSet[processRef];
 
       return household !== undefined && household.documents !== undefined;
     }
@@ -59,20 +58,20 @@ export const SectionsPage: NextPage = () => {
   const householdComplete = useValidateData(
     Storage.ProcessContext,
     ["household"],
-    tmpProcessRef
+    processRef
   );
   const propertyInspectionStarted = useValidateData(
     Storage.ProcessContext,
     ["property"],
-    tmpProcessRef,
+    processRef,
     valueSets => {
       const propertySet = valueSets.property;
 
-      if (propertySet === undefined) {
+      if (propertySet === undefined || processRef === undefined) {
         return false;
       }
 
-      const property = propertySet[tmpProcessRef];
+      const property = propertySet[processRef];
 
       return property !== undefined && property.rooms !== undefined;
     }
@@ -80,15 +79,15 @@ export const SectionsPage: NextPage = () => {
   const propertyInspectionComplete = useValidateData(
     Storage.ProcessContext,
     ["property"],
-    tmpProcessRef,
+    processRef,
     valueSets => {
       const propertySet = valueSets.property;
 
-      if (propertySet === undefined) {
+      if (propertySet === undefined || processRef === undefined) {
         return false;
       }
 
-      const property = propertySet[tmpProcessRef];
+      const property = propertySet[processRef];
 
       return (
         property !== undefined &&
@@ -101,15 +100,15 @@ export const SectionsPage: NextPage = () => {
   const wellbeingSupportStarted = useValidateData(
     Storage.ProcessContext,
     ["homeCheck"],
-    tmpProcessRef,
+    processRef,
     valueSets => {
       const homeCheckSet = valueSets.homeCheck;
 
-      if (homeCheckSet === undefined) {
+      if (homeCheckSet === undefined || processRef === undefined) {
         return false;
       }
 
-      const homeCheck = homeCheckSet[tmpProcessRef];
+      const homeCheck = homeCheckSet[processRef];
 
       return homeCheck !== undefined;
     }
@@ -117,15 +116,15 @@ export const SectionsPage: NextPage = () => {
   const wellbeingSupportComplete = useValidateData(
     Storage.ProcessContext,
     ["homeCheck", "healthConcerns", "disability"],
-    tmpProcessRef,
+    processRef,
     valueSets => {
       const homeCheckSet = valueSets.homeCheck;
 
-      if (homeCheckSet === undefined) {
+      if (homeCheckSet === undefined || processRef === undefined) {
         return false;
       }
 
-      const homeCheck = homeCheckSet[tmpProcessRef];
+      const homeCheck = homeCheckSet[processRef];
 
       return (
         homeCheck !== undefined &&

--- a/pages/thc/[processRef]/verify.tsx
+++ b/pages/thc/[processRef]/verify.tsx
@@ -20,7 +20,6 @@ import useDataValue from "../../../helpers/useDataValue";
 import MainLayout from "../../../layouts/MainLayout";
 import PageSlugs, { urlObjectForSlug } from "../../../steps/PageSlugs";
 import PageTitles from "../../../steps/PageTitles";
-import tmpProcessRef from "../../../storage/processRef";
 import Storage from "../../../storage/Storage";
 
 export const VerifyPage: NextPage = () => {
@@ -43,8 +42,8 @@ export const VerifyPage: NextPage = () => {
   const tenantsPresent = useDataValue(
     Storage.ProcessContext,
     "tenantsPresent",
-    tmpProcessRef,
-    values => values[tmpProcessRef]
+    processRef,
+    values => (processRef ? values[processRef] : undefined)
   );
   const idData = useDataSet(
     Storage.ResidentContext,

--- a/steps/household/household.tsx
+++ b/steps/household/household.tsx
@@ -18,8 +18,8 @@ import {
   TextAreaDetails,
   TextAreaDetailsProps
 } from "../../components/TextAreaDetails";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -68,7 +68,7 @@ const step = {
             "household"
           >({
             storeName: "household",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["documents", "images"]
           })
         })
@@ -131,7 +131,7 @@ const step = {
             "household"
           >({
             storeName: "household",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["houseMovingSchemes", "notes"]
           })
         })
@@ -153,7 +153,7 @@ const step = {
             "household"
           >({
             storeName: "household",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["memberChanges", "notes"]
           })
         })

--- a/steps/household/other-property.tsx
+++ b/steps/household/other-property.tsx
@@ -9,8 +9,8 @@ import {
 import { makeSubmit } from "../../components/makeSubmit";
 import { RadioButtons } from "../../components/RadioButtons";
 import { TextArea, TextAreaProps } from "../../components/TextArea";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -55,7 +55,7 @@ const step = {
             "household"
           >({
             storeName: "household",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["otherProperty", "hasOtherProperty"]
           })
         })
@@ -87,7 +87,7 @@ const step = {
             "household"
           >({
             storeName: "household",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["otherProperty", "notes"]
           })
         })

--- a/steps/household/rent.tsx
+++ b/steps/household/rent.tsx
@@ -18,8 +18,8 @@ import {
   TextAreaDetails,
   TextAreaDetailsProps
 } from "../../components/TextAreaDetails";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -75,7 +75,7 @@ const step = {
             "household"
           >({
             storeName: "household",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["rentArrears", "type"]
           })
         })
@@ -97,7 +97,7 @@ const step = {
             "household"
           >({
             storeName: "household",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["rentArrears", "notes"]
           })
         })
@@ -157,7 +157,7 @@ const step = {
             "household"
           >({
             storeName: "household",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["housingBenefits", "hasApplied"]
           })
         })
@@ -191,7 +191,7 @@ const step = {
             "household"
           >({
             storeName: "household",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["housingBenefits", "notes"]
           })
         })
@@ -289,7 +289,7 @@ const step = {
             "household"
           >({
             storeName: "household",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["incomeOfficer", "wantsToContact"]
           })
         })
@@ -319,7 +319,7 @@ const step = {
             "household"
           >({
             storeName: "household",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["incomeOfficer", "notes"]
           })
         })

--- a/steps/id-and-residency/carer.tsx
+++ b/steps/id-and-residency/carer.tsx
@@ -163,7 +163,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "carer"> = {
             "carer"
           >({
             storeName: "carer",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["hasCarer"]
           })
         })
@@ -191,7 +191,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "carer"> = {
             "carer"
           >({
             storeName: "carer",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["type"]
           })
         })
@@ -219,7 +219,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "carer"> = {
             "carer"
           >({
             storeName: "carer",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["isLiveIn"]
           })
         })
@@ -257,7 +257,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "carer"> = {
             "carer"
           >({
             storeName: "carer",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["liveInStartDate"]
           })
         })
@@ -297,7 +297,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "carer"> = {
             "carer"
           >({
             storeName: "carer",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["fullName"]
           })
         })
@@ -322,7 +322,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "carer"> = {
             "carer"
           >({
             storeName: "carer",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["relationship"]
           })
         })
@@ -347,7 +347,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "carer"> = {
             "carer"
           >({
             storeName: "carer",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["phoneNumber"]
           })
         })
@@ -384,7 +384,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "carer"> = {
             "carer"
           >({
             storeName: "carer",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["address"]
           })
         })
@@ -411,7 +411,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "carer"> = {
             "carer"
           >({
             storeName: "carer",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["notes"]
           })
         })

--- a/steps/id-and-residency/id.tsx
+++ b/steps/id-and-residency/id.tsx
@@ -96,7 +96,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "id"> = {
           emptyValue: "",
           databaseMap: new ComponentDatabaseMap<ResidentDatabaseSchema, "id">({
             storeName: "id",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["type"]
           })
         })
@@ -119,7 +119,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "id"> = {
           emptyValue: [] as string[],
           databaseMap: new ComponentDatabaseMap<ResidentDatabaseSchema, "id">({
             storeName: "id",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["images"]
           })
         })
@@ -138,7 +138,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "id"> = {
           emptyValue: { value: "", isPostVisitAction: false },
           databaseMap: new ComponentDatabaseMap<ResidentDatabaseSchema, "id">({
             storeName: "id",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["notes"]
           })
         })

--- a/steps/id-and-residency/next-of-kin.tsx
+++ b/steps/id-and-residency/next-of-kin.tsx
@@ -102,7 +102,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "nextOfKin"> = {
             "nextOfKin"
           >({
             storeName: "nextOfKin",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["fullName"]
           })
         })
@@ -122,7 +122,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "nextOfKin"> = {
             "nextOfKin"
           >({
             storeName: "nextOfKin",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["relationship"]
           })
         })
@@ -142,7 +142,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "nextOfKin"> = {
             "nextOfKin"
           >({
             storeName: "nextOfKin",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["mobileNumber"]
           })
         })
@@ -162,7 +162,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "nextOfKin"> = {
             "nextOfKin"
           >({
             storeName: "nextOfKin",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["otherNumber"]
           })
         })
@@ -182,7 +182,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "nextOfKin"> = {
             "nextOfKin"
           >({
             storeName: "nextOfKin",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["email"]
           })
         })
@@ -214,7 +214,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "nextOfKin"> = {
             "nextOfKin"
           >({
             storeName: "nextOfKin",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["address"]
           })
         })

--- a/steps/id-and-residency/present-for-check.tsx
+++ b/steps/id-and-residency/present-for-check.tsx
@@ -9,10 +9,10 @@ import {
 import { Checkboxes, CheckboxesProps } from "../../components/Checkboxes";
 import { makeSubmit } from "../../components/makeSubmit";
 import getProcessRef from "../../helpers/getProcessRef";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessStepDefinition from "../../helpers/ProcessStepDefinition";
 import useDataValue from "../../helpers/useDataValue";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import tmpProcessRef from "../../storage/processRef";
 import Storage from "../../storage/Storage";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
@@ -79,7 +79,7 @@ const step: ProcessStepDefinition<ProcessDatabaseSchema, "tenantsPresent"> = {
             "tenantsPresent"
           >({
             storeName: "tenantsPresent",
-            key: tmpProcessRef
+            key: keyFromSlug()
           })
         })
       )

--- a/steps/id-and-residency/residency.tsx
+++ b/steps/id-and-residency/residency.tsx
@@ -113,7 +113,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "residency"> = {
             "residency"
           >({
             storeName: "residency",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["type"]
           })
         })
@@ -139,7 +139,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "residency"> = {
             "residency"
           >({
             storeName: "residency",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["images"]
           })
         })
@@ -161,7 +161,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "residency"> = {
             "residency"
           >({
             storeName: "residency",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["notes"]
           })
         })

--- a/steps/id-and-residency/tenant-photo.tsx
+++ b/steps/id-and-residency/tenant-photo.tsx
@@ -83,7 +83,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "photo"> = {
             "photo"
           >({
             storeName: "photo",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["isWilling"]
           })
         })
@@ -113,7 +113,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "photo"> = {
             "photo"
           >({
             storeName: "photo",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["notes"]
           })
         })
@@ -164,7 +164,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "photo"> = {
             "photo"
           >({
             storeName: "photo",
-            key: keyFromSlug(),
+            key: keyFromSlug(true),
             property: ["images"]
           })
         })

--- a/steps/previsit/about-visit.tsx
+++ b/steps/previsit/about-visit.tsx
@@ -9,8 +9,8 @@ import {
 import { makeSubmit } from "../../components/makeSubmit";
 import { RadioButtons } from "../../components/RadioButtons";
 import { TextArea } from "../../components/TextArea";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -53,7 +53,7 @@ const step = {
             "isUnannouncedVisit"
           >({
             storeName: "isUnannouncedVisit",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["value"]
           })
         })
@@ -83,7 +83,7 @@ const step = {
             "isUnannouncedVisit"
           >({
             storeName: "isUnannouncedVisit",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["notes"]
           })
         })
@@ -117,7 +117,7 @@ const step = {
             "isVisitInside"
           >({
             storeName: "isVisitInside",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["value"]
           })
         })
@@ -148,7 +148,7 @@ const step = {
             "isVisitInside"
           >({
             storeName: "isVisitInside",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["notes"]
           })
         })

--- a/steps/previsit/outside.ts
+++ b/steps/previsit/outside.ts
@@ -11,8 +11,8 @@ import {
 } from "remultiform/component-wrapper";
 import { ImageInput } from "../../components/ImageInput";
 import { makeSubmit } from "../../components/makeSubmit";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -74,7 +74,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["outside", "images"]
           })
         })
@@ -109,7 +109,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["metalGates", "images"]
           })
         })

--- a/steps/property-inspection/antisocial-behaviour.tsx
+++ b/steps/property-inspection/antisocial-behaviour.tsx
@@ -15,8 +15,8 @@ import {
 import { makeSubmit } from "../../components/makeSubmit";
 import { RadioButtons } from "../../components/RadioButtons";
 import { TextArea, TextAreaProps } from "../../components/TextArea";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -96,7 +96,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["antisocialBehaviour", "tenantUnderstands"]
           })
         })
@@ -133,7 +133,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["antisocialBehaviour", "notes"]
           })
         })

--- a/steps/property-inspection/communal-areas.tsx
+++ b/steps/property-inspection/communal-areas.tsx
@@ -9,8 +9,8 @@ import {
 import { makeSubmit } from "../../components/makeSubmit";
 import { RadioButtons } from "../../components/RadioButtons";
 import { TextArea, TextAreaProps } from "../../components/TextArea";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -55,7 +55,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["communalAreas", "hasLeftCombustibleItems"]
           })
         })
@@ -95,7 +95,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["communalAreas", "furtherActionRequired"]
           })
         })
@@ -126,7 +126,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["communalAreas", "notes"]
           })
         })

--- a/steps/property-inspection/damage.tsx
+++ b/steps/property-inspection/damage.tsx
@@ -10,8 +10,8 @@ import { ImageInput } from "../../components/ImageInput";
 import { makeSubmit } from "../../components/makeSubmit";
 import { RadioButtons } from "../../components/RadioButtons";
 import { TextArea, TextAreaProps } from "../../components/TextArea";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -56,7 +56,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["damage", "hasDamage"]
           })
         })
@@ -86,7 +86,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["damage", "images"]
           })
         })
@@ -115,7 +115,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["damage", "notes"]
           })
         })

--- a/steps/property-inspection/door-mats.tsx
+++ b/steps/property-inspection/door-mats.tsx
@@ -9,8 +9,8 @@ import {
 import { makeSubmit } from "../../components/makeSubmit";
 import { RadioButtons } from "../../components/RadioButtons";
 import { TextArea, TextAreaProps } from "../../components/TextArea";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -56,7 +56,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["doorMats", "hasPlaced"]
           })
         })
@@ -93,7 +93,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["doorMats", "furtherActionRequired"]
           })
         })
@@ -121,7 +121,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["doorMats", "notes"]
           })
         })

--- a/steps/property-inspection/fire-exit.tsx
+++ b/steps/property-inspection/fire-exit.tsx
@@ -9,8 +9,8 @@ import {
 import { makeSubmit } from "../../components/makeSubmit";
 import { RadioButtons } from "../../components/RadioButtons";
 import { TextArea, TextAreaProps } from "../../components/TextArea";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -55,7 +55,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["fireExit", "hasFireExit"]
           })
         })
@@ -92,7 +92,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["fireExit", "isAccessible"]
           })
         })
@@ -120,7 +120,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["fireExit", "notes"]
           })
         })

--- a/steps/property-inspection/garden.tsx
+++ b/steps/property-inspection/garden.tsx
@@ -10,8 +10,8 @@ import { ImageInput } from "../../components/ImageInput";
 import { makeSubmit } from "../../components/makeSubmit";
 import { RadioButtons } from "../../components/RadioButtons";
 import { TextArea, TextAreaProps } from "../../components/TextArea";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -54,7 +54,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["garden", "hasGarden"]
           })
         })
@@ -97,7 +97,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["garden", "type"]
           })
         })
@@ -137,7 +137,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["garden", "isMaintained"]
           })
         })
@@ -167,7 +167,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["garden", "images"]
           })
         })
@@ -195,7 +195,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["garden", "notes"]
           })
         })

--- a/steps/property-inspection/laminated-flooring.tsx
+++ b/steps/property-inspection/laminated-flooring.tsx
@@ -10,8 +10,8 @@ import { ImageInput } from "../../components/ImageInput";
 import { makeSubmit } from "../../components/makeSubmit";
 import { RadioButtons } from "../../components/RadioButtons";
 import { TextArea, TextAreaProps } from "../../components/TextArea";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -56,7 +56,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["laminatedFlooring", "hasLaminatedFlooring"]
           })
         })
@@ -98,7 +98,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["laminatedFlooring", "hasPermission"]
           })
         })
@@ -131,7 +131,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["laminatedFlooring", "images"]
           })
         })
@@ -162,7 +162,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["laminatedFlooring", "notes"]
           })
         })

--- a/steps/property-inspection/loft.tsx
+++ b/steps/property-inspection/loft.tsx
@@ -9,8 +9,8 @@ import {
 import { makeSubmit } from "../../components/makeSubmit";
 import { RadioButtons } from "../../components/RadioButtons";
 import { TextArea, TextAreaProps } from "../../components/TextArea";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -55,7 +55,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["loft", "hasAccess"]
           })
         })
@@ -97,7 +97,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["loft", "itemsStored"]
           })
         })
@@ -128,7 +128,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["loft", "notes"]
           })
         })

--- a/steps/property-inspection/metal-gates.tsx
+++ b/steps/property-inspection/metal-gates.tsx
@@ -10,8 +10,8 @@ import { ImageInput } from "../../components/ImageInput";
 import { makeSubmit } from "../../components/makeSubmit";
 import { RadioButtons } from "../../components/RadioButtons";
 import { TextArea, TextAreaProps } from "../../components/TextArea";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -57,7 +57,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["metalGates", "hasMetalGates"]
           })
         })
@@ -99,7 +99,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["metalGates", "combustibleItemsBehind"]
           })
         })
@@ -139,7 +139,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["metalGates", "furtherActionRequired"]
           })
         })
@@ -172,7 +172,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["metalGates", "images"]
           })
         })
@@ -204,7 +204,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["metalGates", "notes"]
           })
         })

--- a/steps/property-inspection/other-comments.tsx
+++ b/steps/property-inspection/other-comments.tsx
@@ -13,8 +13,8 @@ import {
 import { ImageInput } from "../../components/ImageInput";
 import { makeSubmit } from "../../components/makeSubmit";
 import { TextArea, TextAreaProps } from "../../components/TextArea";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -75,7 +75,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["otherComments", "images"]
           })
         })
@@ -99,7 +99,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["otherComments", "notes"]
           })
         })

--- a/steps/property-inspection/pets.tsx
+++ b/steps/property-inspection/pets.tsx
@@ -11,8 +11,8 @@ import { ImageInput } from "../../components/ImageInput";
 import { makeSubmit } from "../../components/makeSubmit";
 import { RadioButtons } from "../../components/RadioButtons";
 import { TextArea, TextAreaProps } from "../../components/TextArea";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -57,7 +57,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["pets", "hasPets"]
           })
         })
@@ -130,7 +130,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["pets", "petTypes"]
           })
         })
@@ -169,7 +169,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["pets", "hasPermission"]
           })
         })
@@ -198,7 +198,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["pets", "images"]
           })
         })
@@ -226,7 +226,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["pets", "notes"]
           })
         })

--- a/steps/property-inspection/repairs.tsx
+++ b/steps/property-inspection/repairs.tsx
@@ -11,8 +11,8 @@ import { ImageInput } from "../../components/ImageInput";
 import { makeSubmit } from "../../components/makeSubmit";
 import { RadioButtons } from "../../components/RadioButtons";
 import { TextArea, TextAreaProps } from "../../components/TextArea";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -79,7 +79,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["repairs", "needsRepairs"]
           })
         })
@@ -109,7 +109,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["repairs", "images"]
           })
         })
@@ -136,7 +136,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["repairs", "notes"]
           })
         })

--- a/steps/property-inspection/roof.tsx
+++ b/steps/property-inspection/roof.tsx
@@ -9,8 +9,8 @@ import {
 import { makeSubmit } from "../../components/makeSubmit";
 import { RadioButtons } from "../../components/RadioButtons";
 import { TextArea, TextAreaProps } from "../../components/TextArea";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -55,7 +55,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["roof", "hasAccess"]
           })
         })
@@ -94,7 +94,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["roof", "itemsStoredOnRoof"]
           })
         })
@@ -122,7 +122,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["roof", "notes"]
           })
         })

--- a/steps/property-inspection/rooms.tsx
+++ b/steps/property-inspection/rooms.tsx
@@ -9,8 +9,8 @@ import {
 import { makeSubmit } from "../../components/makeSubmit";
 import { RadioButtons } from "../../components/RadioButtons";
 import { TextArea, TextAreaProps } from "../../components/TextArea";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -55,7 +55,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["rooms", "canEnterAll"]
           })
         })
@@ -86,7 +86,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["rooms", "notes"]
           })
         })

--- a/steps/property-inspection/smoke-alarm.tsx
+++ b/steps/property-inspection/smoke-alarm.tsx
@@ -9,8 +9,8 @@ import {
 import { makeSubmit } from "../../components/makeSubmit";
 import { RadioButtons } from "../../components/RadioButtons";
 import { TextArea, TextAreaProps } from "../../components/TextArea";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -55,7 +55,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["smokeAlarm", "hasSmokeAlarm"]
           })
         })
@@ -95,7 +95,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["smokeAlarm", "isWorking"]
           })
         })
@@ -129,7 +129,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["smokeAlarm", "notes"]
           })
         })

--- a/steps/property-inspection/storing-materials.tsx
+++ b/steps/property-inspection/storing-materials.tsx
@@ -9,8 +9,8 @@ import {
 import { makeSubmit } from "../../components/makeSubmit";
 import { RadioButtons } from "../../components/RadioButtons";
 import { TextArea, TextAreaProps } from "../../components/TextArea";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -56,7 +56,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["storingMaterials", "isStoringMaterials"]
           })
         })
@@ -96,7 +96,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["storingMaterials", "furtherActionRequired"]
           })
         })
@@ -127,7 +127,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["storingMaterials", "notes"]
           })
         })

--- a/steps/property-inspection/structural-changes.tsx
+++ b/steps/property-inspection/structural-changes.tsx
@@ -10,8 +10,8 @@ import { ImageInput } from "../../components/ImageInput";
 import { makeSubmit } from "../../components/makeSubmit";
 import { RadioButtons } from "../../components/RadioButtons";
 import { TextArea, TextAreaProps } from "../../components/TextArea";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -57,7 +57,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["structuralChanges", "hasStructuralChanges"]
           })
         })
@@ -99,7 +99,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["structuralChanges", "changesAuthorised"]
           })
         })
@@ -132,7 +132,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["structuralChanges", "images"]
           })
         })
@@ -164,7 +164,7 @@ const step = {
             "property"
           >({
             storeName: "property",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["structuralChanges", "notes"]
           })
         })

--- a/steps/wellbeing-support/disability.tsx
+++ b/steps/wellbeing-support/disability.tsx
@@ -10,8 +10,8 @@ import { Checkboxes, CheckboxesProps } from "../../components/Checkboxes";
 import { makeSubmit } from "../../components/makeSubmit";
 import { RadioButtons } from "../../components/RadioButtons";
 import { TextArea, TextAreaProps } from "../../components/TextArea";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -56,7 +56,7 @@ const step = {
             "disability"
           >({
             storeName: "disability",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["value"]
           })
         })
@@ -101,7 +101,7 @@ const step = {
             "disability"
           >({
             storeName: "disability",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["whoDisability"]
           })
         })
@@ -141,7 +141,7 @@ const step = {
             "disability"
           >({
             storeName: "disability",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["pipOrDLA"]
           })
         })
@@ -186,7 +186,7 @@ const step = {
             "disability"
           >({
             storeName: "disability",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["whoPIP"]
           })
         })
@@ -231,7 +231,7 @@ const step = {
             "disability"
           >({
             storeName: "disability",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["whoDLA"]
           })
         })
@@ -260,7 +260,7 @@ const step = {
             "disability"
           >({
             storeName: "disability",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["notes"]
           })
         })

--- a/steps/wellbeing-support/health.tsx
+++ b/steps/wellbeing-support/health.tsx
@@ -10,8 +10,8 @@ import { Checkboxes, CheckboxesProps } from "../../components/Checkboxes";
 import { makeSubmit } from "../../components/makeSubmit";
 import { RadioButtons } from "../../components/RadioButtons";
 import { TextArea, TextAreaProps } from "../../components/TextArea";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -56,7 +56,7 @@ const step = {
             "healthConcerns"
           >({
             storeName: "healthConcerns",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["value"]
           })
         })
@@ -106,7 +106,7 @@ const step = {
             "healthConcerns"
           >({
             storeName: "healthConcerns",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["who"]
           })
         })
@@ -157,7 +157,7 @@ const step = {
             "healthConcerns"
           >({
             storeName: "healthConcerns",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["moreInfo"]
           })
         })
@@ -189,7 +189,7 @@ const step = {
             "healthConcerns"
           >({
             storeName: "healthConcerns",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["notes"]
           })
         })

--- a/steps/wellbeing-support/home-check.tsx
+++ b/steps/wellbeing-support/home-check.tsx
@@ -10,9 +10,9 @@ import {
 } from "remultiform/component-wrapper";
 import { makeSubmit } from "../../components/makeSubmit";
 import { RadioButtons } from "../../components/RadioButtons";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import yesNoRadios from "../../helpers/yesNoRadios";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -64,7 +64,7 @@ const step = {
             "homeCheck"
           >({
             storeName: "homeCheck",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["value"]
           })
         })

--- a/steps/wellbeing-support/support-needs.tsx
+++ b/steps/wellbeing-support/support-needs.tsx
@@ -13,8 +13,8 @@ import {
   TextAreaDetails,
   TextAreaDetailsProps
 } from "../../components/TextAreaDetails";
+import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessDatabaseSchema from "../../storage/ProcessDatabaseSchema";
-import processRef from "../../storage/processRef";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
@@ -81,7 +81,7 @@ const step = {
             "supportNeeds"
           >({
             storeName: "supportNeeds",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["residentSustainmentNotes"]
           })
         })
@@ -115,7 +115,7 @@ const step = {
             "supportNeeds"
           >({
             storeName: "supportNeeds",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["befriendingNotes"]
           })
         })
@@ -179,7 +179,7 @@ const step = {
             "supportNeeds"
           >({
             storeName: "supportNeeds",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["adultSafeguardingNotes"]
           })
         })
@@ -240,7 +240,7 @@ const step = {
             "supportNeeds"
           >({
             storeName: "supportNeeds",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["childrenYoungPeopleSafeguardingNotes"]
           })
         })
@@ -287,7 +287,7 @@ const step = {
             "supportNeeds"
           >({
             storeName: "supportNeeds",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["domesticSexualViolenceNotes"]
           })
         })
@@ -336,7 +336,7 @@ const step = {
             "supportNeeds"
           >({
             storeName: "supportNeeds",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["mentalHealth18To65Notes"]
           })
         })
@@ -388,7 +388,7 @@ const step = {
             "supportNeeds"
           >({
             storeName: "supportNeeds",
-            key: processRef,
+            key: keyFromSlug(),
             property: ["mentalHealthOver65Notes"]
           })
         })

--- a/storage/Storage.ts
+++ b/storage/Storage.ts
@@ -12,7 +12,6 @@ import ProcessDatabaseSchema, {
   ProcessRef,
   processStoreNames
 } from "./ProcessDatabaseSchema";
-import tmpProcessRef from "./processRef";
 import ResidentDatabaseSchema, {
   residentDatabaseName,
   ResidentRef,
@@ -268,10 +267,7 @@ export default class Storage {
     let processData = (
       await Promise.all(
         processStoreNames.map(async storeName => {
-          // The steps still use the hardcoded `processRef`, so we need to also
-          // use it, even though we're using the correct value to persist to the
-          // backend.
-          const value = await processDatabase.get(storeName, tmpProcessRef);
+          const value = await processDatabase.get(storeName, processRef);
 
           if (storeName === "lastModified") {
             lastModified = value as StoreValue<

--- a/storage/processRef.ts
+++ b/storage/processRef.ts
@@ -1,2 +1,0 @@
-// TEMPORARY
-export default "badbadba-dbad-badb-adba-dbadbadbadba";


### PR DESCRIPTION
Before this change, we were using a hardcoded value due to early versions of `remultiform` only supporting static database keys. It now supports dynamic keys, so we now fetch the key at run time.