### PR TITLE
Stop running the `check` CI job on `development`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,9 @@ workflows:
           name: install-and-test-branch
           filters:
             branches:
-              ignore: master
+              ignore:
+                - development
+                - master
 
       - build:
           name: build-image-on-branch


### PR DESCRIPTION
We do its steps in the deployments.