### PR TITLE
MT3-491 #ready-for-test Explicitly specify inherited `renderWhen` conditions

### DIFF
--- a/steps/id-and-residency/carer.tsx
+++ b/steps/id-and-residency/carer.tsx
@@ -233,9 +233,13 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "carer"> = {
             children: "When did the carer start living in the property?",
           },
           renderWhen(stepValues: {
+            "carer-needed"?: ComponentValue<ResidentDatabaseSchema, "carer">;
             "carer-live-in"?: ComponentValue<ResidentDatabaseSchema, "carer">;
           }): boolean {
-            return stepValues["carer-live-in"] === "yes";
+            return (
+              stepValues["carer-needed"] === "yes" &&
+              stepValues["carer-live-in"] === "yes"
+            );
           },
         })
       ),
@@ -247,9 +251,13 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "carer"> = {
             name: "carer-live-in-start-date",
           },
           renderWhen(stepValues: {
+            "carer-needed"?: ComponentValue<ResidentDatabaseSchema, "carer">;
             "carer-live-in"?: ComponentValue<ResidentDatabaseSchema, "carer">;
           }): boolean {
-            return stepValues["carer-live-in"] === "yes";
+            return (
+              stepValues["carer-needed"] === "yes" &&
+              stepValues["carer-live-in"] === "yes"
+            );
           },
           defaultValue: {},
           emptyValue: {} as { month?: number; year?: number },
@@ -374,9 +382,13 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "carer"> = {
             rows: 4 as number | undefined,
           },
           renderWhen(stepValues: {
+            "carer-needed"?: ComponentValue<ResidentDatabaseSchema, "carer">;
             "carer-live-in"?: ComponentValue<ResidentDatabaseSchema, "carer">;
           }): boolean {
-            return stepValues["carer-live-in"] === "no";
+            return (
+              stepValues["carer-needed"] === "yes" &&
+              stepValues["carer-live-in"] !== "yes"
+            );
           },
           defaultValue: "",
           emptyValue: "",

--- a/steps/property-inspection/garden.tsx
+++ b/steps/property-inspection/garden.tsx
@@ -155,11 +155,13 @@ const step: ProcessStepDefinition<ProcessDatabaseSchema, "property"> = {
             radios: yesNoRadios,
           },
           renderWhen(stepValues: {
+            "has-garden"?: ComponentValue<ProcessDatabaseSchema, "property">;
             "garden-type"?: ComponentValue<ProcessDatabaseSchema, "property">;
           }): boolean {
             return (
-              stepValues["garden-type"] === "private" ||
-              stepValues["garden-type"] === "not sure"
+              stepValues["has-garden"] === "yes" &&
+              (stepValues["garden-type"] === "private" ||
+                stepValues["garden-type"] === "not sure")
             );
           },
           defaultValue: "",

--- a/steps/property-inspection/metal-gates.tsx
+++ b/steps/property-inspection/metal-gates.tsx
@@ -155,12 +155,19 @@ const step: ProcessStepDefinition<ProcessDatabaseSchema, "property"> = {
             radios: yesNoRadios,
           },
           renderWhen(stepValues: {
+            "has-metal-gates"?: ComponentValue<
+              ProcessDatabaseSchema,
+              "property"
+            >;
             "combustible-items-behind-gates"?: ComponentValue<
               ProcessDatabaseSchema,
               "property"
             >;
           }): boolean {
-            return stepValues["combustible-items-behind-gates"] === "yes";
+            return (
+              stepValues["has-metal-gates"] === "yes" &&
+              stepValues["combustible-items-behind-gates"] === "yes"
+            );
           },
           defaultValue: "",
           emptyValue: "",

--- a/steps/property-inspection/pets.tsx
+++ b/steps/property-inspection/pets.tsx
@@ -213,12 +213,16 @@ const step: ProcessStepDefinition<ProcessDatabaseSchema, "property"> = {
             maxCount: 1 as number | null | undefined,
           },
           renderWhen(stepValues: {
+            "has-pets"?: ComponentValue<ProcessDatabaseSchema, "property">;
             "has-permission"?: ComponentValue<
               ProcessDatabaseSchema,
               "property"
             >;
           }): boolean {
-            return stepValues["has-permission"] === "yes";
+            return (
+              stepValues["has-pets"] === "yes" &&
+              stepValues["has-permission"] === "yes"
+            );
           },
           defaultValue: [],
           emptyValue: [] as string[],

--- a/steps/wellbeing-support/disability.tsx
+++ b/steps/wellbeing-support/disability.tsx
@@ -198,9 +198,13 @@ const step: ProcessStepDefinition<ProcessDatabaseSchema, "disability"> = {
             checkboxes: householdMemberCheckboxes,
           } as CheckboxesProps,
           renderWhen(stepValues: {
+            disability?: ComponentValue<ProcessDatabaseSchema, "disability">;
             "pip-or-dla"?: ComponentValue<ProcessDatabaseSchema, "disability">;
           }): boolean {
-            return stepValues["pip-or-dla"] === "yes";
+            return (
+              stepValues["disability"] === "yes" &&
+              stepValues["pip-or-dla"] === "yes"
+            );
           },
           defaultValue: [],
           emptyValue: [] as string[],
@@ -226,9 +230,13 @@ const step: ProcessStepDefinition<ProcessDatabaseSchema, "disability"> = {
             checkboxes: householdMemberCheckboxes,
           } as CheckboxesProps,
           renderWhen(stepValues: {
+            disability?: ComponentValue<ProcessDatabaseSchema, "disability">;
             "pip-or-dla"?: ComponentValue<ProcessDatabaseSchema, "disability">;
           }): boolean {
-            return stepValues["pip-or-dla"] === "yes";
+            return (
+              stepValues["disability"] === "yes" &&
+              stepValues["pip-or-dla"] === "yes"
+            );
           },
           defaultValue: [],
           emptyValue: [] as string[],


### PR DESCRIPTION
Without this change, filling in a chain of questions then returning to
an earlier question in the chain and changing the answer results in the
questions that depend on questions no longer visible remain visible.
This is because the no invisible question's answer is still stored ready
to be submitted. We do this because we don't want to destroy the user's
answers due to e.g. a misclick.