### PR TITLE
MT3-653 Display multiple tenants on Review Sign & Submit

### DIFF
--- a/components/ReviewSection.tsx
+++ b/components/ReviewSection.tsx
@@ -1,0 +1,41 @@
+import {
+  Heading,
+  HeadingLevels,
+  Paragraph,
+  SummaryList,
+} from "lbh-frontend-react";
+import React from "react";
+import PropTypes from "../helpers/PropTypes";
+import { SectionRow } from "../helpers/useReviewSectionRows";
+
+interface Props {
+  heading: string;
+  rows?: SectionRow[];
+}
+
+export const ReviewSection: React.FunctionComponent<Props> = (props) => {
+  const { heading, rows } = props || {};
+
+  return (
+    <>
+      <Heading level={HeadingLevels.H2}>{heading}</Heading>
+      {rows && rows.length ? (
+        <SummaryList
+          rows={(rows as unknown) as { key: string; value: string }[]}
+        />
+      ) : (
+        <Paragraph>Loading...</Paragraph>
+      )}
+    </>
+  );
+};
+
+ReviewSection.propTypes = {
+  heading: PropTypes.string.isRequired,
+  rows: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string.isRequired,
+      value: PropTypes.string.isRequired,
+    }).isRequired
+  ),
+};

--- a/components/ReviewSection.tsx
+++ b/components/ReviewSection.tsx
@@ -20,9 +20,7 @@ export const ReviewSection: React.FunctionComponent<Props> = (props) => {
     <>
       <Heading level={HeadingLevels.H2}>{heading}</Heading>
       {rows && rows.length ? (
-        <SummaryList
-          rows={(rows as unknown) as { key: string; value: string }[]}
-        />
+        <SummaryList rows={rows} />
       ) : (
         <Paragraph>Loading...</Paragraph>
       )}

--- a/components/review-sections/HouseholdReviewSection.tsx
+++ b/components/review-sections/HouseholdReviewSection.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import useReviewSectionRows from "../../helpers/useReviewSectionRows";
+import householdSteps from "../../steps/household";
+import Storage from "../../storage/Storage";
+import { ReviewSection } from "../ReviewSection";
+
+export const HouseholdReviewSection: React.FunctionComponent = () => {
+  const rows = useReviewSectionRows(Storage.ProcessContext, householdSteps);
+  return <ReviewSection heading={"Household"} rows={rows} />;
+};

--- a/components/review-sections/IdAndResidencyReviewSection.tsx
+++ b/components/review-sections/IdAndResidencyReviewSection.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import PropTypes from "../../helpers/PropTypes";
+import useReviewSectionRows from "../../helpers/useReviewSectionRows";
+import {
+  idAndResidencyProcessSteps,
+  idAndResidencyResidentSteps,
+} from "../../steps/id-and-residency";
+import Storage from "../../storage/Storage";
+import { ReviewSection } from "../ReviewSection";
+
+interface Props {
+  selectedTenantId: string;
+}
+
+export const IdAndResidencyReviewSection: React.FunctionComponent<Props> = (
+  props
+) => {
+  const { selectedTenantId } = props;
+
+  return (
+    <ReviewSection
+      section={{
+        heading: "ID, residency, and tenant information",
+        rows: [
+          ...useReviewSectionRows(
+            Storage.ProcessContext,
+            idAndResidencyProcessSteps
+          ),
+          ...useReviewSectionRows(
+            Storage.ResidentContext,
+            idAndResidencyResidentSteps,
+            selectedTenantId
+          ),
+        ],
+      }}
+    />
+  );
+};
+
+IdAndResidencyReviewSection.propTypes = {
+  selectedTenantId: PropTypes.string.isRequired,
+};

--- a/components/review-sections/IdAndResidencyReviewSection.tsx
+++ b/components/review-sections/IdAndResidencyReviewSection.tsx
@@ -1,3 +1,9 @@
+import {
+  Heading,
+  HeadingLevels,
+  Paragraph,
+  SummaryList,
+} from "lbh-frontend-react";
 import React from "react";
 import PropTypes from "../../helpers/PropTypes";
 import useReviewSectionRows from "../../helpers/useReviewSectionRows";
@@ -6,37 +12,85 @@ import {
   idAndResidencyResidentSteps,
 } from "../../steps/id-and-residency";
 import Storage from "../../storage/Storage";
-import { ReviewSection } from "../ReviewSection";
 
-interface Props {
-  selectedTenantId: string;
+interface Tenant {
+  fullName: string;
+  id: string;
+  present: boolean;
+}
+interface IdAndResidencyReviewSectionProps {
+  tenants: Tenant[];
 }
 
-export const IdAndResidencyReviewSection: React.FunctionComponent<Props> = (
-  props
-) => {
-  const { selectedTenantId } = props;
+interface TenantSectionProps {
+  tenant: Tenant;
+}
+
+const TenantSection: React.FunctionComponent<TenantSectionProps> = (props) => {
+  const { tenant } = props;
+  const { id, fullName, present } = tenant;
+  const rows = useReviewSectionRows(
+    Storage.ResidentContext,
+    idAndResidencyResidentSteps,
+    id
+  );
 
   return (
-    <ReviewSection
-      section={{
-        heading: "ID, residency, and tenant information",
-        rows: [
-          ...useReviewSectionRows(
-            Storage.ProcessContext,
-            idAndResidencyProcessSteps
-          ),
-          ...useReviewSectionRows(
-            Storage.ResidentContext,
-            idAndResidencyResidentSteps,
-            selectedTenantId
-          ),
-        ],
-      }}
-    />
+    <>
+      {rows && rows.length ? (
+        <>
+          <Heading level={HeadingLevels.H3}>
+            {fullName}
+            {present ? "" : " (not present)"}
+          </Heading>
+          <SummaryList rows={rows} />
+        </>
+      ) : (
+        <Paragraph>Loading...</Paragraph>
+      )}
+    </>
   );
 };
 
+export const IdAndResidencyReviewSection: React.FunctionComponent<IdAndResidencyReviewSectionProps> = (
+  props
+) => {
+  const { tenants } = props;
+
+  const rows = useReviewSectionRows(
+    Storage.ProcessContext,
+    idAndResidencyProcessSteps
+  );
+
+  console.log(rows);
+
+  return (
+    <>
+      <Heading level={HeadingLevels.H2}>
+        ID, residency, and tenant information
+      </Heading>
+      {rows && rows.length > 0 && <SummaryList rows={rows} />}
+      {tenants.map((tenant) => (
+        <TenantSection key={tenant.id} tenant={tenant} />
+      ))}
+    </>
+  );
+};
+
+TenantSection.propTypes = {
+  tenant: PropTypes.shape({
+    fullName: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+    present: PropTypes.bool.isRequired,
+  }).isRequired,
+};
+
 IdAndResidencyReviewSection.propTypes = {
-  selectedTenantId: PropTypes.string.isRequired,
+  tenants: PropTypes.arrayOf(
+    PropTypes.shape({
+      fullName: PropTypes.string.isRequired,
+      id: PropTypes.string.isRequired,
+      present: PropTypes.bool.isRequired,
+    }).isRequired
+  ).isRequired,
 };

--- a/components/review-sections/PropertyInspectionReviewSection.tsx
+++ b/components/review-sections/PropertyInspectionReviewSection.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import useReviewSectionRows from "../../helpers/useReviewSectionRows";
+import propertyInspectionSteps from "../../steps/property-inspection";
+import Storage from "../../storage/Storage";
+import { ReviewSection } from "../ReviewSection";
+
+export const PropertyInspectionReviewSection: React.FunctionComponent = () => {
+  const rows = useReviewSectionRows(
+    Storage.ProcessContext,
+    propertyInspectionSteps
+  );
+  return <ReviewSection heading={"Property inspection"} rows={rows} />;
+};

--- a/components/review-sections/WellbeingSupportReviewSection.tsx
+++ b/components/review-sections/WellbeingSupportReviewSection.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import useReviewSectionRows from "../../helpers/useReviewSectionRows";
+import WellbeingSupportSteps from "../../steps/wellbeing-support";
+import Storage from "../../storage/Storage";
+import { ReviewSection } from "../ReviewSection";
+
+export const WellbeingSupportReviewSection: React.FunctionComponent = () => {
+  const rows = useReviewSectionRows(
+    Storage.ProcessContext,
+    WellbeingSupportSteps
+  );
+  return <ReviewSection heading={"Wellbeing support"} rows={rows} />;
+};

--- a/pages/thc/[processRef]/review.tsx
+++ b/pages/thc/[processRef]/review.tsx
@@ -13,6 +13,7 @@ import { makeSubmit } from "../../../components/makeSubmit";
 import { PostVisitActionInput } from "../../../components/PostVisitActionInput";
 import { HouseholdReviewSection } from "../../../components/review-sections/HouseholdReviewSection";
 import { IdAndResidencyReviewSection } from "../../../components/review-sections/IdAndResidencyReviewSection";
+import { PropertyInspectionReviewSection } from "../../../components/review-sections/PropertyInspectionReviewSection";
 import Signature from "../../../components/Signature";
 import Thumbnail from "../../../components/Thumbnail";
 import getProcessRef from "../../../helpers/getProcessRef";
@@ -22,7 +23,6 @@ import useReviewSectionRows from "../../../helpers/useReviewSectionRows";
 import MainLayout from "../../../layouts/MainLayout";
 import PageSlugs from "../../../steps/PageSlugs";
 import PageTitles from "../../../steps/PageTitles";
-import propertyInspectionSteps from "../../../steps/property-inspection";
 import wellbeingSupportSteps from "../../../steps/wellbeing-support";
 import { ResidentRef } from "../../../storage/ResidentDatabaseSchema";
 import Storage from "../../../storage/Storage";
@@ -121,15 +121,6 @@ const ReviewPage: NextPage = () => {
 
   const sections = [
     {
-      heading: "Property inspection",
-      rows: [
-        ...useReviewSectionRows(
-          Storage.ProcessContext,
-          propertyInspectionSteps
-        ),
-      ],
-    },
-    {
       heading: "Wellbeing support",
       rows: [
         ...useReviewSectionRows(Storage.ProcessContext, wellbeingSupportSteps),
@@ -194,6 +185,7 @@ const ReviewPage: NextPage = () => {
         <IdAndResidencyReviewSection selectedTenantId={selectedTenantId} />
       )}
       <HouseholdReviewSection />
+      <PropertyInspectionReviewSection />
       {sections
         .filter((section) => section.rows.length)
         .map((section) => {

--- a/pages/thc/[processRef]/review.tsx
+++ b/pages/thc/[processRef]/review.tsx
@@ -189,16 +189,21 @@ const ReviewPage: NextPage = () => {
       <Paragraph>
         Date of visit: {formatDate(new Date(), "d MMMM yyyy")}
       </Paragraph>
-      <Signature
-        value={selectedTenantId && signatures[selectedTenantId]}
-        onChange={(value): void => {
-          if (!selectedTenantId) {
-            return;
-          }
+      {tenantsPresent.map(({ fullName, id }) => (
+        <React.Fragment key={id}>
+          <Heading level={HeadingLevels.H3}>{fullName}</Heading>
+          <Signature
+            value={id && signatures[id]}
+            onChange={(value): void => {
+              if (!id) {
+                return;
+              }
 
-          setSignatures((sigs) => ({ ...sigs, [selectedTenantId]: value }));
-        }}
-      />
+              setSignatures((sigs) => ({ ...sigs, [id]: value }));
+            }}
+          />
+        </React.Fragment>
+      ))}
       <SubmitButton
         disabled={
           !processRef ||
@@ -216,11 +221,13 @@ const ReviewPage: NextPage = () => {
             return false;
           }
 
-          await residentDatabase.result.put(
-            "signature",
-            selectedTenantId,
-            signatures[selectedTenantId] || ""
-          );
+          for (const tenantId of presentTenantIds) {
+            await residentDatabase.result.put(
+              "signature",
+              tenantId,
+              signatures[tenantId] || ""
+            );
+          }
 
           await processDatabase.result.put(
             "otherNotes",

--- a/pages/thc/[processRef]/review.tsx
+++ b/pages/thc/[processRef]/review.tsx
@@ -11,6 +11,7 @@ import { useRouter } from "next/router";
 import React, { useState } from "react";
 import { makeSubmit } from "../../../components/makeSubmit";
 import { PostVisitActionInput } from "../../../components/PostVisitActionInput";
+import { HouseholdReviewSection } from "../../../components/review-sections/HouseholdReviewSection";
 import { IdAndResidencyReviewSection } from "../../../components/review-sections/IdAndResidencyReviewSection";
 import Signature from "../../../components/Signature";
 import Thumbnail from "../../../components/Thumbnail";
@@ -19,7 +20,6 @@ import useDatabase from "../../../helpers/useDatabase";
 import useDataValue from "../../../helpers/useDataValue";
 import useReviewSectionRows from "../../../helpers/useReviewSectionRows";
 import MainLayout from "../../../layouts/MainLayout";
-import householdSteps from "../../../steps/household";
 import PageSlugs from "../../../steps/PageSlugs";
 import PageTitles from "../../../steps/PageTitles";
 import propertyInspectionSteps from "../../../steps/property-inspection";
@@ -121,10 +121,6 @@ const ReviewPage: NextPage = () => {
 
   const sections = [
     {
-      heading: "Household",
-      rows: [...useReviewSectionRows(Storage.ProcessContext, householdSteps)],
-    },
-    {
       heading: "Property inspection",
       rows: [
         ...useReviewSectionRows(
@@ -197,6 +193,7 @@ const ReviewPage: NextPage = () => {
       {selectedTenantId && (
         <IdAndResidencyReviewSection selectedTenantId={selectedTenantId} />
       )}
+      <HouseholdReviewSection />
       {sections
         .filter((section) => section.rows.length)
         .map((section) => {

--- a/pages/thc/[processRef]/review.tsx
+++ b/pages/thc/[processRef]/review.tsx
@@ -92,22 +92,12 @@ const ReviewPage: NextPage = () => {
   const presentTenantNames = tenantsPresent.map(({ fullName }) => fullName);
   const presentTenantIds = tenantsPresent.map(({ id }) => id);
 
-  const [selectedTenantId, setSelectedTenantId] = useState<
-    ResidentRef | undefined
-  >();
-
   const outsidePropertyImages = useDataValue(
     Storage.ProcessContext,
     "property",
     processRef,
     (values) => (processRef ? values[processRef]?.outside : undefined)
   );
-
-  // Long term we want an interface that allows the user to select which tenant
-  // to use, but for now we stick to the first tenant in the list.
-  if (selectedTenantId !== presentTenantIds[0]) {
-    setSelectedTenantId(presentTenantIds[0]);
-  }
 
   const SubmitButton = makeSubmit({
     slug: PageSlugs.Submit,
@@ -207,16 +197,12 @@ const ReviewPage: NextPage = () => {
       ))}
       <SubmitButton
         disabled={
-          !processRef ||
-          !residentDatabase.result ||
-          !selectedTenantId ||
-          !processDatabase.result
+          !processRef || !residentDatabase.result || !processDatabase.result
         }
         onSubmit={async (): Promise<boolean> => {
           if (
             !processRef ||
             !residentDatabase.result ||
-            !selectedTenantId ||
             !processDatabase.result
           ) {
             return false;

--- a/pages/thc/[processRef]/review.tsx
+++ b/pages/thc/[processRef]/review.tsx
@@ -47,9 +47,11 @@ const ReviewPage: NextPage = () => {
   );
 
   const tenantIdsPresentForCheckValue = tenantIdsPresentForCheck.result || [];
-  const tenantsPresent = tenantsValue.filter((tenant) =>
-    tenantIdsPresentForCheckValue.includes(tenant.id)
-  );
+
+  const tenantsWithPresentStatus = tenantsValue.map((tenant) => ({
+    ...tenant,
+    present: tenantIdsPresentForCheckValue.includes(tenant.id),
+  }));
 
   const address = useDataValue(
     Storage.ExternalContext,
@@ -83,6 +85,10 @@ const ReviewPage: NextPage = () => {
   ]);
 
   const allTenantNames = tenantsValue.map(({ fullName }) => fullName);
+
+  const tenantsPresent = tenantsValue.filter((tenant) =>
+    tenantIdsPresentForCheckValue.includes(tenant.id)
+  );
   const presentTenantNames = tenantsPresent.map(({ fullName }) => fullName);
   const presentTenantIds = tenantsPresent.map(({ id }) => id);
 
@@ -162,15 +168,10 @@ const ReviewPage: NextPage = () => {
           ? presentTenantNames.join(", ")
           : "Loading..."}
       </Paragraph>
-      {tenantsPresent.map(({ fullName, id }) => (
-        <React.Fragment key={id}>
-          <Heading level={HeadingLevels.H2}>{fullName}</Heading>
-          <IdAndResidencyReviewSection selectedTenantId={id} />
-          <HouseholdReviewSection />
-          <PropertyInspectionReviewSection />
-          <WellbeingSupportReviewSection />
-        </React.Fragment>
-      ))}
+      <IdAndResidencyReviewSection tenants={tenantsWithPresentStatus} />
+      <HouseholdReviewSection />
+      <PropertyInspectionReviewSection />
+      <WellbeingSupportReviewSection />
       <PostVisitActionInput
         value={otherNotes}
         onValueChange={(notes): void => setOtherNotes(notes)}

--- a/pages/thc/[processRef]/review.tsx
+++ b/pages/thc/[processRef]/review.tsx
@@ -11,6 +11,7 @@ import { useRouter } from "next/router";
 import React, { useState } from "react";
 import { makeSubmit } from "../../../components/makeSubmit";
 import { PostVisitActionInput } from "../../../components/PostVisitActionInput";
+import { IdAndResidencyReviewSection } from "../../../components/review-sections/IdAndResidencyReviewSection";
 import Signature from "../../../components/Signature";
 import Thumbnail from "../../../components/Thumbnail";
 import getProcessRef from "../../../helpers/getProcessRef";
@@ -19,10 +20,6 @@ import useDataValue from "../../../helpers/useDataValue";
 import useReviewSectionRows from "../../../helpers/useReviewSectionRows";
 import MainLayout from "../../../layouts/MainLayout";
 import householdSteps from "../../../steps/household";
-import {
-  idAndResidencyProcessSteps,
-  idAndResidencyResidentSteps,
-} from "../../../steps/id-and-residency";
 import PageSlugs from "../../../steps/PageSlugs";
 import PageTitles from "../../../steps/PageTitles";
 import propertyInspectionSteps from "../../../steps/property-inspection";
@@ -124,20 +121,6 @@ const ReviewPage: NextPage = () => {
 
   const sections = [
     {
-      heading: "ID, residency, and tenant information",
-      rows: [
-        ...useReviewSectionRows(
-          Storage.ProcessContext,
-          idAndResidencyProcessSteps
-        ),
-        ...useReviewSectionRows(
-          Storage.ResidentContext,
-          idAndResidencyResidentSteps,
-          selectedTenantId
-        ),
-      ],
-    },
-    {
       heading: "Household",
       rows: [...useReviewSectionRows(Storage.ProcessContext, householdSteps)],
     },
@@ -210,6 +193,9 @@ const ReviewPage: NextPage = () => {
       </Paragraph>
       {tenantsPresent.length > 0 && (
         <Paragraph>Present for check: {tenantsPresent.join(", ")}</Paragraph>
+      )}
+      {selectedTenantId && (
+        <IdAndResidencyReviewSection selectedTenantId={selectedTenantId} />
       )}
       {sections
         .filter((section) => section.rows.length)

--- a/pages/thc/[processRef]/review.tsx
+++ b/pages/thc/[processRef]/review.tsx
@@ -1,3 +1,4 @@
+import { ReviewSection } from "components/ReviewSection";
 import formatDate from "date-fns/format";
 import {
   Heading,
@@ -212,19 +213,9 @@ const ReviewPage: NextPage = () => {
       )}
       {sections
         .filter((section) => section.rows.length)
-        .map(({ heading, rows }) => (
-          <React.Fragment key={heading}>
-            <Heading level={HeadingLevels.H2}>{heading}</Heading>
-
-            {rows.length ? (
-              <SummaryList
-                rows={(rows as unknown) as { key: string; value: string }[]}
-              />
-            ) : (
-              <Paragraph>Loading...</Paragraph>
-            )}
-          </React.Fragment>
-        ))}
+        .map((section) => {
+          return <ReviewSection key={section.heading} section={section} />;
+        })}
       <PostVisitActionInput
         value={otherNotes}
         onValueChange={(notes): void => setOtherNotes(notes)}

--- a/pages/thc/[processRef]/review.tsx
+++ b/pages/thc/[processRef]/review.tsx
@@ -1,4 +1,3 @@
-import { ReviewSection } from "components/ReviewSection";
 import formatDate from "date-fns/format";
 import {
   Heading,
@@ -14,16 +13,15 @@ import { PostVisitActionInput } from "../../../components/PostVisitActionInput";
 import { HouseholdReviewSection } from "../../../components/review-sections/HouseholdReviewSection";
 import { IdAndResidencyReviewSection } from "../../../components/review-sections/IdAndResidencyReviewSection";
 import { PropertyInspectionReviewSection } from "../../../components/review-sections/PropertyInspectionReviewSection";
+import { WellbeingSupportReviewSection } from "../../../components/review-sections/WellbeingSupportReviewSection";
 import Signature from "../../../components/Signature";
 import Thumbnail from "../../../components/Thumbnail";
 import getProcessRef from "../../../helpers/getProcessRef";
 import useDatabase from "../../../helpers/useDatabase";
 import useDataValue from "../../../helpers/useDataValue";
-import useReviewSectionRows from "../../../helpers/useReviewSectionRows";
 import MainLayout from "../../../layouts/MainLayout";
 import PageSlugs from "../../../steps/PageSlugs";
 import PageTitles from "../../../steps/PageTitles";
-import wellbeingSupportSteps from "../../../steps/wellbeing-support";
 import { ResidentRef } from "../../../storage/ResidentDatabaseSchema";
 import Storage from "../../../storage/Storage";
 
@@ -119,15 +117,6 @@ const ReviewPage: NextPage = () => {
     setSelectedTenantId(tenantIds[0]);
   }
 
-  const sections = [
-    {
-      heading: "Wellbeing support",
-      rows: [
-        ...useReviewSectionRows(Storage.ProcessContext, wellbeingSupportSteps),
-      ],
-    },
-  ];
-
   const SubmitButton = makeSubmit({
     slug: PageSlugs.Submit,
     value: "Save and finish process",
@@ -186,11 +175,7 @@ const ReviewPage: NextPage = () => {
       )}
       <HouseholdReviewSection />
       <PropertyInspectionReviewSection />
-      {sections
-        .filter((section) => section.rows.length)
-        .map((section) => {
-          return <ReviewSection key={section.heading} section={section} />;
-        })}
+      <WellbeingSupportReviewSection />
       <PostVisitActionInput
         value={otherNotes}
         onValueChange={(notes): void => setOtherNotes(notes)}


### PR DESCRIPTION
We've decided to display all sections for all tenants in one long list, as we haven't got any filtering components at the moment to allow housing officers to select a single tenant to view on the Review page.

This PR also refactors a couple of checks for `undefined` values when calling `.result` on values that are returned from the database to make them slightly easier to work with.