### PR TITLE
MT3-668 #ready-for-test Fix joint tenants issue

### DIFF
--- a/helpers/slugForRepeatingStep.ts
+++ b/helpers/slugForRepeatingStep.ts
@@ -2,8 +2,9 @@ import router from "next/router";
 import PageSlugs from "../steps/PageSlugs";
 import idFromSlug from "./idFromSlug";
 import isServer from "./isServer";
+import slugWithId from "./slugWithId";
 
-const nextSlugWithId = (nextSlug: PageSlugs, id?: string): (() => string) => {
+const slugForRepeatingStep = (nextSlug: PageSlugs): (() => string) => {
   return (): string => {
     if (isServer) {
       return "";
@@ -11,10 +12,14 @@ const nextSlugWithId = (nextSlug: PageSlugs, id?: string): (() => string) => {
 
     // `router.query` might be an empty object when first loading a page for
     // some reason.
-    id = id || idFromSlug(router, router.query.slug);
+    const id = idFromSlug(router, router.query.slug);
 
-    return [nextSlug, id].join("/");
+    if (!id) {
+      return "";
+    }
+
+    return slugWithId(nextSlug, id);
   };
 };
 
-export default nextSlugWithId;
+export default slugForRepeatingStep;

--- a/helpers/slugWithId.ts
+++ b/helpers/slugWithId.ts
@@ -1,0 +1,7 @@
+import PageSlugs from "../steps/PageSlugs";
+
+const slugWithId = (slug: PageSlugs, id: string): string => {
+  return [slug, id].join("/");
+};
+
+export default slugWithId;

--- a/pages/thc/[processRef]/verify.tsx
+++ b/pages/thc/[processRef]/verify.tsx
@@ -13,7 +13,7 @@ import React from "react";
 import { Table } from "../../../components/Table";
 import { TenancySummary } from "../../../components/TenancySummary";
 import getProcessRef from "../../../helpers/getProcessRef";
-import nextSlugWithId from "../../../helpers/nextSlugWithId";
+import slugWithId from "../../../helpers/slugWithId";
 import urlsForRouter from "../../../helpers/urlsForRouter";
 import useDataSet from "../../../helpers/useDataSet";
 import useDataValue from "../../../helpers/useDataValue";
@@ -103,8 +103,7 @@ export const VerifyPage: NextPage = () => {
       <Link
         key="verify-link"
         href={
-          urlObjectForSlug(router, nextSlugWithId(PageSlugs.Id, tenant.id)())
-            .pathname
+          urlObjectForSlug(router, slugWithId(PageSlugs.Id, tenant.id)).pathname
         }
       >
         {tenantsPresent.loading

--- a/steps/id-and-residency/carer.tsx
+++ b/steps/id-and-residency/carer.tsx
@@ -26,8 +26,8 @@ import { ReviewNotes } from "../../components/ReviewNotes";
 import { TextInput } from "../../components/TextInput";
 import { getRadioLabelFromValue } from "../../helpers/getRadioLabelFromValue";
 import keyFromSlug from "../../helpers/keyFromSlug";
-import nextSlugWithId from "../../helpers/nextSlugWithId";
 import ProcessStepDefinition from "../../helpers/ProcessStepDefinition";
+import slugForRepeatingStep from "../../helpers/slugForRepeatingStep";
 import yesNoRadios from "../../helpers/yesNoRadios";
 import { Notes } from "../../storage/DatabaseSchema";
 import ResidentDatabaseSchema from "../../storage/ResidentDatabaseSchema";
@@ -140,7 +140,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "carer"> = {
   },
   step: {
     slug: PageSlugs.Carer,
-    nextSlug: nextSlugWithId(PageSlugs.OtherSupport),
+    nextSlug: slugForRepeatingStep(PageSlugs.OtherSupport),
     submit: (nextSlug?: string): ReturnType<typeof makeSubmit> =>
       makeSubmit({
         slug: nextSlug as PageSlugs | undefined,

--- a/steps/id-and-residency/id.tsx
+++ b/steps/id-and-residency/id.tsx
@@ -15,8 +15,8 @@ import { RadioButtons } from "../../components/RadioButtons";
 import { ReviewNotes } from "../../components/ReviewNotes";
 import { getRadioLabelFromValue } from "../../helpers/getRadioLabelFromValue";
 import keyFromSlug from "../../helpers/keyFromSlug";
-import nextSlugWithId from "../../helpers/nextSlugWithId";
 import ProcessStepDefinition from "../../helpers/ProcessStepDefinition";
+import slugForRepeatingStep from "../../helpers/slugForRepeatingStep";
 import { Notes } from "../../storage/DatabaseSchema";
 import ResidentDatabaseSchema from "../../storage/ResidentDatabaseSchema";
 import Storage from "../../storage/Storage";
@@ -81,7 +81,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "id"> = {
   },
   step: {
     slug: PageSlugs.Id,
-    nextSlug: nextSlugWithId(PageSlugs.Residency),
+    nextSlug: slugForRepeatingStep(PageSlugs.Residency),
     submit: (nextSlug?: string): ReturnType<typeof makeSubmit> =>
       makeSubmit({
         slug: nextSlug as PageSlugs | undefined,

--- a/steps/id-and-residency/next-of-kin.tsx
+++ b/steps/id-and-residency/next-of-kin.tsx
@@ -1,21 +1,21 @@
 import {
   Heading,
   HeadingLevels,
-  Textarea,
   LabelProps,
+  Textarea,
 } from "lbh-frontend-react";
 import {
   ComponentDatabaseMap,
   ComponentWrapper,
   DynamicComponent,
-  StaticComponent,
   makeDynamic,
+  StaticComponent,
 } from "remultiform/component-wrapper";
 import { makeSubmit } from "../../components/makeSubmit";
 import { TextInput } from "../../components/TextInput";
 import keyFromSlug from "../../helpers/keyFromSlug";
-import nextSlugWithId from "../../helpers/nextSlugWithId";
 import ProcessStepDefinition from "../../helpers/ProcessStepDefinition";
+import slugForRepeatingStep from "../../helpers/slugForRepeatingStep";
 import ResidentDatabaseSchema from "../../storage/ResidentDatabaseSchema";
 import Storage from "../../storage/Storage";
 import PageSlugs from "../PageSlugs";
@@ -70,7 +70,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "nextOfKin"> = {
   },
   step: {
     slug: PageSlugs.NextOfKin,
-    nextSlug: nextSlugWithId(PageSlugs.Carer),
+    nextSlug: slugForRepeatingStep(PageSlugs.Carer),
     submit: (nextSlug?: string): ReturnType<typeof makeSubmit> =>
       makeSubmit({
         slug: nextSlug as PageSlugs | undefined,

--- a/steps/id-and-residency/residency.tsx
+++ b/steps/id-and-residency/residency.tsx
@@ -14,8 +14,8 @@ import {
 import { RadioButtons } from "../../components/RadioButtons";
 import { ReviewNotes } from "../../components/ReviewNotes";
 import keyFromSlug from "../../helpers/keyFromSlug";
-import nextSlugWithId from "../../helpers/nextSlugWithId";
 import ProcessStepDefinition from "../../helpers/ProcessStepDefinition";
+import slugForRepeatingStep from "../../helpers/slugForRepeatingStep";
 import { Notes } from "../../storage/DatabaseSchema";
 import ResidentDatabaseSchema from "../../storage/ResidentDatabaseSchema";
 import Storage from "../../storage/Storage";
@@ -95,7 +95,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "residency"> = {
   },
   step: {
     slug: PageSlugs.Residency,
-    nextSlug: nextSlugWithId(PageSlugs.TenantPhoto),
+    nextSlug: slugForRepeatingStep(PageSlugs.TenantPhoto),
     submit: (nextSlug?: string): ReturnType<typeof makeSubmit> =>
       makeSubmit({
         slug: nextSlug as PageSlugs | undefined,

--- a/steps/id-and-residency/tenant-photo.tsx
+++ b/steps/id-and-residency/tenant-photo.tsx
@@ -17,8 +17,8 @@ import { PostVisitActionInput } from "../../components/PostVisitActionInput";
 import { RadioButtons } from "../../components/RadioButtons";
 import { ReviewNotes } from "../../components/ReviewNotes";
 import keyFromSlug from "../../helpers/keyFromSlug";
-import nextSlugWithId from "../../helpers/nextSlugWithId";
 import ProcessStepDefinition from "../../helpers/ProcessStepDefinition";
+import slugForRepeatingStep from "../../helpers/slugForRepeatingStep";
 import yesNoRadios from "../../helpers/yesNoRadios";
 import { Notes } from "../../storage/DatabaseSchema";
 import ResidentDatabaseSchema from "../../storage/ResidentDatabaseSchema";
@@ -57,7 +57,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "photo"> = {
   },
   step: {
     slug: PageSlugs.TenantPhoto,
-    nextSlug: nextSlugWithId(PageSlugs.NextOfKin),
+    nextSlug: slugForRepeatingStep(PageSlugs.NextOfKin),
     submit: (nextSlug?: string): ReturnType<typeof makeSubmit> =>
       makeSubmit({
         slug: nextSlug as PageSlugs | undefined,


### PR DESCRIPTION
It turns out `id = id || idFromSlug(router, router.query.slug)` was modifying the argument included by closure, overwriting `id` every time the function was called. Splitting the behaviour into 2 distinct functions makes it clearer what's going on.