### PR TITLE
MT3-399 #ready-for-test Fix household member review page

### DIFF
--- a/steps/household/household.tsx
+++ b/steps/household/household.tsx
@@ -1,3 +1,4 @@
+import formatDate from "date-fns/format";
 import {
   Heading,
   HeadingLevels,
@@ -55,7 +56,7 @@ const HouseholdMembersTable: React.FunctionComponent = () => {
                 ({ fullName, relationship, dateOfBirth }) => [
                   fullName,
                   relationship,
-                  dateOfBirth,
+                  formatDate(dateOfBirth, "d MMMM yyyy"),
                 ]
               )
             : [["None"]]


### PR DESCRIPTION
This was trying to render the Date object and causing an error - now it formats the date as a string.

For one case I tested, relationships were coming back as `null` which probably means they weren't set in outsystems, as the other case I tested displayed the relationships correctly - I wonder if we want to render a string like "N/A" or "Not set in Outsystems" instead?