### PR TITLE
Remove the notes field from `homeCheck`

### DIFF
--- a/storage/ProcessDatabaseSchema.ts
+++ b/storage/ProcessDatabaseSchema.ts
@@ -181,7 +181,6 @@ type ProcessDatabaseSchema = NamedSchema<
       key: ProcessRef;
       value: {
         value: string;
-        notes: Notes;
       };
     };
 
@@ -323,8 +322,7 @@ export const processNotesPaths: {
     "incomeOfficer.notes",
     "otherProperty.notes",
   ],
-  // Is there even a notes field for homeCheck?
-  homeCheck: ["notes"],
+  homeCheck: [],
   healthConcerns: ["notes"],
   disability: ["notes"],
   supportNeeds: [


### PR DESCRIPTION
We don't have anything to capture notes on the page.
