### PR TITLE
Specify a cache first strategy for internal pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -39,4 +39,20 @@ module.exports = withOffline({
   env,
   registerSwPrefix: basePath,
   scope: `${basePath}/`,
+  workboxOpts: {
+    exclude: [/\/api\//],
+    runtimeCaching: [
+      {
+        urlPattern: /^https?.*/,
+        handler: "CacheFirst",
+        method: "GET",
+        options: {
+          cacheName: "offlineCache",
+          expiration: {
+            maxEntries: 200,
+          },
+        },
+      },
+    ],
+  },
 });


### PR DESCRIPTION
Our builds are hashed in their paths, so we if we have a cached version,
we can use that with priority.

We want to exclude API paths from the caching as they are not guaranteed
to be idempotent.

This may help with flakiness when reloading certain pages.