### PR TITLE
Fix/ Prevent creation of empty PVAs

### DIFF
--- a/helpers/persistPostVisitActions.ts
+++ b/helpers/persistPostVisitActions.ts
@@ -272,7 +272,7 @@ export const persistPostVisitActions = async (
 
       await Promise.all(
         notes.map(async (note, index) => {
-          if (note.createdAt) {
+          if (note.createdAt || note.value === "") {
             return;
           }
 
@@ -318,7 +318,7 @@ export const persistPostVisitActions = async (
 
         await Promise.all(
           notes.map(async (note, index) => {
-            if (note.createdAt) {
+            if (note.createdAt || note.value === "") {
               return;
             }
 

--- a/pages/thc/[processRef]/pause.tsx
+++ b/pages/thc/[processRef]/pause.tsx
@@ -59,10 +59,9 @@ const PausePage: NextPage = () => {
                 : "You are currently working offline."}
             </Paragraph>
             <Paragraph>
-              The Tenancy and Household Check for the tenancy at
-              {address} occupied by {tenants} has been saved to your device but
-              still needs to be saved to your work tray so you can resume it
-              later.
+              The Tenancy and Household Check for the tenancy at {address}{" "}
+              occupied by {tenants} has been saved to your device but still
+              needs to be saved to your work tray so you can resume it later.
             </Paragraph>
             <Paragraph>
               <strong>You need to be online on this device to continue.</strong>


### PR DESCRIPTION
This was initially preventing submission of a process when a user tried to create a post visit action with an empty note value.

Also adds missing whitespace around the address on the Submit page. 
