### PR TITLE
Remove references to tenancy in confirmation pages

### DIFF
--- a/__tests__/pages/thc/[processRef]/confirmed.test.tsx
+++ b/__tests__/pages/thc/[processRef]/confirmed.test.tsx
@@ -124,7 +124,11 @@ it("renders correctly", () => {
             <div
               className="lbh-page-announcement__content"
             >
-              Loading...
+              <p
+                className="lbh-body"
+              >
+                The Tenancy and Household Check has been submitted for manager review.
+              </p>
             </div>
           </section>
           <h3

--- a/pages/thc/[processRef]/confirmed.tsx
+++ b/pages/thc/[processRef]/confirmed.tsx
@@ -8,35 +8,19 @@ import {
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 import React from "react";
-import getProcessRef from "../../../helpers/getProcessRef";
 import isManager from "../../../helpers/isManager";
-import useDataValue from "../../../helpers/useDataValue";
 import MainLayout from "../../../layouts/MainLayout";
 import PageTitles from "../../../steps/PageTitles";
-import Storage from "../../../storage/Storage";
 
 const ConfirmedPage: NextPage = () => {
   const router = useRouter();
-  const processRef = getProcessRef(router);
   const isManagerPage = isManager(router);
 
   const { status } = router.query;
 
-  const residentData = useDataValue(
-    Storage.ExternalContext,
-    "residents",
-    processRef,
-    (values) => (processRef ? values[processRef] : undefined)
-  );
-
-  const address = residentData.result?.address.join(", ");
-  const tenants = (residentData.result?.tenants || [])
-    .map((tenant) => tenant.fullName)
-    .join(", ");
-
-  const managerApprovedText = `The Tenancy and Household Check for the tenancy at ${address}, occupied by ${tenants} has been approved by you.`;
-  const managerDeclinedText = `The Tenancy and Household Check for the tenancy at ${address}, occupied by ${tenants} has been declined by you. The Housing Officer will be notified.`;
-  const officerText = `The Tenancy and Household Check for the tenancy at ${address}, occupied by ${tenants} has been submitted for manager review.`;
+  const managerApprovedText = `The Tenancy and Household Check has been approved by you.`;
+  const managerDeclinedText = `The Tenancy and Household Check has been declined by you. The Housing Officer will be notified.`;
+  const officerText = `The Tenancy and Household Check has been submitted for manager review.`;
 
   const managerText = status
     ? status === "2"
@@ -47,11 +31,7 @@ const ConfirmedPage: NextPage = () => {
   return (
     <MainLayout title={PageTitles.Confirmed}>
       <PageAnnouncement title="Process submission confirmed">
-        {residentData.loading ? (
-          "Loading..."
-        ) : (
-          <Paragraph>{isManagerPage ? managerText : officerText}</Paragraph>
-        )}
+        <Paragraph>{isManagerPage ? managerText : officerText}</Paragraph>
       </PageAnnouncement>
 
       <Heading level={HeadingLevels.H3}>What to do next?</Heading>

--- a/pages/thc/[processRef]/paused.tsx
+++ b/pages/thc/[processRef]/paused.tsx
@@ -2,42 +2,18 @@ import { Button } from "lbh-frontend-react/components/Button";
 import { PageAnnouncement } from "lbh-frontend-react/components/PageAnnouncement";
 import { Paragraph } from "lbh-frontend-react/components/typography/Paragraph";
 import { NextPage } from "next";
-import { useRouter } from "next/router";
 import React from "react";
-import getProcessRef from "../../../helpers/getProcessRef";
-import useDataValue from "../../../helpers/useDataValue";
 import MainLayout from "../../../layouts/MainLayout";
 import PageTitles from "../../../steps/PageTitles";
-import Storage from "../../../storage/Storage";
 
 const PausedPage: NextPage = () => {
-  const router = useRouter();
-  const processRef = getProcessRef(router);
-
-  const residentData = useDataValue(
-    Storage.ExternalContext,
-    "residents",
-    processRef,
-    (values) => (processRef ? values[processRef] : undefined)
-  );
-
-  const address = residentData.result?.address.join(", ");
-  const tenants = (residentData.result?.tenants || [])
-    .map((tenant) => tenant.fullName)
-    .join(", ");
-
   return (
     <MainLayout title={PageTitles.Paused}>
       <PageAnnouncement title="Process paused">
-        {residentData.loading ? (
-          "Loading..."
-        ) : (
-          <Paragraph>
-            The Tenancy and Household Check for the tenancy at {address},
-            occupied by {tenants} has been paused and saved to your work tray
-            ready to continue later.
-          </Paragraph>
-        )}
+        <Paragraph>
+          The Tenancy and Household Check has been paused and saved to your work
+          tray ready to continue later.
+        </Paragraph>
       </PageAnnouncement>
 
       <Paragraph>


### PR DESCRIPTION
We have cleared the local storage at that point, so they won't ever exist.