### PR TITLE
Provide environment variables to Docker during build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,15 +52,29 @@ jobs:
           command: TEST_BROWSER=chrome npm test
 
   build:
+    parameters:
+      environment-name:
+        type: string
+      worktray-url:
+        type: string
+      diversity-form-url:
+        type: string
+
     docker:
       - image: docker:stable-git
+
     steps:
       - checkout
       - setup_remote_docker
 
       - run:
           name: Build Docker image
-          command: docker build .
+          command: |
+            docker build . \
+              --build-args ENVIRONMENT_NAME="<<parameters.environment-name>>" \
+              --build-args PROCESS_NAME="thc" \
+              --build-args WORKTRAY_URL="<<parameters.worktray-url>>" \
+              --build-args DIVERSITY_FORM_URL="<<parameters.diversity-form-url>>"
 
   deploy:
     parameters:
@@ -95,6 +109,9 @@ workflows:
           name: build-image-on-branch
           requires:
             - install-and-test-branch
+          environment-name: branch
+          worktray-url: https://work.tray
+          diversity-form-url: https://diversity.form
 
   check-and-deploy-to-development-and-staging:
     jobs:
@@ -111,6 +128,11 @@ workflows:
           account-url: AWS_ECR_HOST
           aws-access-key-id: AWS_ACCESS_KEY_ID
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          extra-build-args: |
+            --build-args ENVIRONMENT_NAME="development" \
+            --build-args PROCESS_NAME="thc" \
+            --build-args WORKTRAY_URL="https://hlbctrial-dev.outsystemsenterprise.com/manageatenancy/OfficerDashboard.aspx" \
+            --build-args DIVERSITY_FORM_URL="https://docs.google.com/forms/d/e/1FAIpQLScDI85GMCFl8c02DYGpf_cOxsjD83FNbNFEIWKs4u_HOydhKA/viewform"
           region: AWS_REGION
           repo: $AWS_ECR_PATH_DEV
           tag: $CIRCLE_SHA1
@@ -130,6 +152,11 @@ workflows:
           account-url: AWS_ECR_HOST
           aws-access-key-id: AWS_ACCESS_KEY_ID
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          extra-build-args: |
+            --build-args ENVIRONMENT_NAME="staging" \
+            --build-args PROCESS_NAME="thc" \
+            --build-args WORKTRAY_URL="https://hlbctrial-tst.outsystemsenterprise.com/manageatenancy/OfficerDashboard.aspx" \
+            --build-args DIVERSITY_FORM_URL="https://docs.google.com/forms/d/e/1FAIpQLScDI85GMCFl8c02DYGpf_cOxsjD83FNbNFEIWKs4u_HOydhKA/viewform"
           region: AWS_REGION
           repo: $AWS_ECR_PATH_STAGING
           tag: $CIRCLE_SHA1
@@ -157,6 +184,11 @@ workflows:
           account-url: AWS_ECR_HOST
           aws-access-key-id: AWS_ACCESS_KEY_ID
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          extra-build-args: |
+            --build-args ENVIRONMENT_NAME="production" \
+            --build-args PROCESS_NAME="thc" \
+            --build-args WORKTRAY_URL="https://hlbctrial.outsystemsenterprise.com/manageatenancy/OfficerDashboard.aspx" \
+            --build-args DIVERSITY_FORM_URL="https://docs.google.com/forms/d/e/1FAIpQLScDI85GMCFl8c02DYGpf_cOxsjD83FNbNFEIWKs4u_HOydhKA/viewform"
           region: AWS_REGION
           repo: $AWS_ECR_PATH_PRODUCTION
           tag: $CIRCLE_SHA1

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,11 @@ RUN apk add --no-cache bash
 
 WORKDIR /app
 
+ARG ENVIRONMENT_NAME
+ARG PROCESS_NAME
+ARG WORKTRAY_URL
+ARG DIVERSITY_FORM_URL
+
 ENV NODE_ENV production
 
 # ------------------------------------------------------------------------------

--- a/next.config.js
+++ b/next.config.js
@@ -28,6 +28,12 @@ if (dev) {
   });
 }
 
+for (const [key, value] of Object.entries(env)) {
+  if (value === undefined) {
+    throw new Error(`Environment value ${key} is required but missing`);
+  }
+}
+
 module.exports = withOffline({
   assetPrefix: basePath,
   distDir: process.env.NEXT_DIST_DIR || ".next",

--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,8 @@ const basePath = require("./server/helpers/basePath");
 
 const dev = process.env.NODE_ENV !== "production";
 
+// Environment variables need to be set at build time to have them be included
+// in the client files.
 const env = {
   ENVIRONMENT_NAME: process.env.ENVIRONMENT_NAME,
   PROCESS_NAME: process.env.PROCESS_NAME,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:unit:watch": "npm run test:unit -- --watch",
     "test:feature": "PORT=3001 concurrently --names 'server,test' 'npm run test:feature:server' 'npm run test:feature:run' --kill-others --success first",
     "test:feature:update": "PORT=3001 concurrently --names 'server,test' 'npm run test:feature:server' 'npm run test:feature:run -- --updateSnapshot' --kill-others --success first",
-    "test:feature:server": "export NEXT_DIST_DIR=.next-test && export DISABLE_MAT_PROCESS_ACTIONS=1 && npm run build && npm start",
+    "test:feature:server": "export NEXT_DIST_DIR=.next-test && export DISABLE_MAT_PROCESS_ACTIONS=1 && export ENVIRONMENT_NAME=test && export PROCESS_NAME=thc && export WORKTRAY_URL=https://work.tray && export DIVERSITY_FORM_URL=https://diversity.form && npm run build && npm start",
     "test:feature:run": "wait-for-localhost ${PORT:-3000} && jest --config jest.config.feature.js --runInBand",
     "lint": "eslint --report-unused-disable-directives --config ./.eslintrc.full.js '**/*.{js,jsx,ts,tsx}'",
     "lint:fix": "npm run lint -- --fix",


### PR DESCRIPTION
In order for the client JavaScript to contain environment variables,
they must be provided at build time. Before this change, none of them
were coming through to the client.