### PR TITLE
MT3-656 #ready-for-test Unable to Enter review page

### DIFF
--- a/components/PreviousAttemptsAnnouncement.tsx
+++ b/components/PreviousAttemptsAnnouncement.tsx
@@ -8,6 +8,7 @@ import { useRouter } from "next/router";
 import React from "react";
 import failedAttemptActionCheckboxes from "../helpers/failedAttemptActionCheckboxes";
 import failedAttemptReasonCheckboxes from "../helpers/failedAttemptReasonCheckboxes";
+import { getCheckboxLabelsFromValues } from "../helpers/getCheckboxLabelsFromValues";
 import getProcessRef from "../helpers/getProcessRef";
 import useDataValue from "../helpers/useDataValue";
 import Storage from "../storage/Storage";
@@ -24,10 +25,10 @@ const Value: React.FunctionComponent<{
   const actions = props.actions || [];
   const notes = props.notes;
 
-  const reason = failedAttemptReasonCheckboxes
-    .filter((checkbox) => reasons.includes(checkbox.value))
-    .map((checkbox) => checkbox.label)
-    .join(", ");
+  const reason = getCheckboxLabelsFromValues(
+    failedAttemptReasonCheckboxes,
+    reasons
+  );
 
   const action = failedAttemptActionCheckboxes
     .filter((checkbox) => actions.includes(checkbox.value))

--- a/helpers/getCheckboxLabelsFromValues.ts
+++ b/helpers/getCheckboxLabelsFromValues.ts
@@ -1,0 +1,9 @@
+export const getCheckboxLabelsFromValues = (
+  checkboxes: { label: string; value: string }[],
+  values: string[]
+): string => {
+  return checkboxes
+    .filter(({ value }) => values.includes(value))
+    .map(({ label }) => label)
+    .join(", ");
+};

--- a/pages/thc/[processRef]/unable-to-enter-review.tsx
+++ b/pages/thc/[processRef]/unable-to-enter-review.tsx
@@ -1,0 +1,197 @@
+import formatDate from "date-fns/format";
+import { Paragraph, Textarea } from "lbh-frontend-react";
+import { NextPage } from "next";
+import { useRouter } from "next/router";
+import React, { useState } from "react";
+import { TransactionMode } from "remultiform/database";
+import { makeSubmit } from "../../../components/makeSubmit";
+import { ReviewSection } from "../../../components/ReviewSection";
+import { TenancySummary } from "../../../components/TenancySummary";
+import getProcessRef from "../../../helpers/getProcessRef";
+import useDatabase from "../../../helpers/useDatabase";
+import useDataValue from "../../../helpers/useDataValue";
+import useReviewSectionRows from "../../../helpers/useReviewSectionRows";
+import MainLayout from "../../../layouts/MainLayout";
+import PageSlugs from "../../../steps/PageSlugs";
+import PageTitles from "../../../steps/PageTitles";
+import firstFailedAttempt from "../../../steps/unable-to-enter/first-failed-attempt";
+import fourthFailedAttempt from "../../../steps/unable-to-enter/fourth-failed-attempt";
+import secondFailedAttempt from "../../../steps/unable-to-enter/second-failed-attempt";
+import thirdFailedAttempt from "../../../steps/unable-to-enter/third-failed-attempt";
+import ProcessDatabaseSchema from "../../../storage/ProcessDatabaseSchema";
+import Storage from "../../../storage/Storage";
+
+const UnableToEnterReviewPage: NextPage = () => {
+  const router = useRouter();
+
+  const processRef = getProcessRef(router);
+
+  const tenants = useDataValue(
+    Storage.ExternalContext,
+    "residents",
+    processRef,
+    (values) => (processRef ? values[processRef]?.tenants : undefined)
+  );
+
+  const tenantsValue = tenants.result || [];
+
+  const address = useDataValue(
+    Storage.ExternalContext,
+    "residents",
+    processRef,
+    (values) => (processRef ? values[processRef]?.address : undefined)
+  );
+
+  const tenureType = useDataValue(
+    Storage.ExternalContext,
+    "tenancy",
+    processRef,
+    (values) => (processRef ? values[processRef]?.tenureType : undefined)
+  );
+
+  const tenancyStartDate = useDataValue(
+    Storage.ExternalContext,
+    "tenancy",
+    processRef,
+    (values) => (processRef ? values[processRef]?.startDate : undefined)
+  );
+
+  const failedAttempts = useDataValue(
+    Storage.ProcessContext,
+    "unableToEnter",
+    processRef,
+    (values) => (processRef ? values[processRef] : undefined)
+  );
+
+  const formatDateWithTime = (date: string): string => {
+    return formatDate(new Date(date), "HH:mm 'on' d MMMM yyyy");
+  };
+
+  const firstFailedAttemptDate = failedAttempts.result
+    ? formatDateWithTime(failedAttempts.result.firstFailedAttempt.date)
+    : "Loading...";
+  const secondFailedAttemptDate = failedAttempts.result
+    ? formatDateWithTime(failedAttempts.result.secondFailedAttempt.date)
+    : "Loading...";
+  const thirdFailedAttemptDate = failedAttempts.result
+    ? formatDateWithTime(failedAttempts.result.thirdFailedAttempt.date)
+    : "Loading...";
+  const fourthFailedAttemptDate = failedAttempts.result
+    ? formatDateWithTime(failedAttempts.result.fourthFailedAttempt.date)
+    : "Loading...";
+
+  const firstFailedAttemptReviewSection = useReviewSectionRows(
+    Storage.ProcessContext,
+    [firstFailedAttempt],
+    true
+  );
+
+  const secondFailedAttemptReviewSection = useReviewSectionRows(
+    Storage.ProcessContext,
+    [secondFailedAttempt],
+    true
+  );
+
+  const thirdFailedAttemptReviewSection = useReviewSectionRows(
+    Storage.ProcessContext,
+    [thirdFailedAttempt],
+    true
+  );
+
+  const fourthFailedAttemptReviewSection = useReviewSectionRows(
+    Storage.ProcessContext,
+    [fourthFailedAttempt],
+    true
+  );
+
+  const processDatabase = useDatabase(Storage.ProcessContext);
+
+  const [otherNotes, setOtherNotes] = useState("");
+
+  const allTenantNames = tenantsValue.map(({ fullName }) => fullName);
+
+  const SubmitButton = makeSubmit({
+    slug: PageSlugs.Submit,
+    value: "Save and finish process",
+  });
+
+  return (
+    <MainLayout
+      title={PageTitles.UnableToEnterReview}
+      heading="Submit Tenancy and Household Check"
+      pausable
+    >
+      <React.Fragment>
+        <TenancySummary
+          details={{
+            address: address.result,
+            tenants: allTenantNames,
+            tenureType: tenureType.result,
+            startDate: tenancyStartDate.result,
+          }}
+        />
+      </React.Fragment>
+      <Paragraph>
+        Four attempts have been made to do a Tenancy and Household Check. The
+        actions taken at each attempt have been recorded.
+      </Paragraph>
+      <ReviewSection
+        heading={`First Failed Attempt: ${firstFailedAttemptDate}`}
+        loading={firstFailedAttemptReviewSection.loading}
+        rows={firstFailedAttemptReviewSection.result}
+      />
+      <ReviewSection
+        heading={`Second Failed Attempt: ${secondFailedAttemptDate}`}
+        loading={secondFailedAttemptReviewSection.loading}
+        rows={secondFailedAttemptReviewSection.result}
+      />
+      <ReviewSection
+        heading={`Third Failed Attempt: ${thirdFailedAttemptDate}`}
+        loading={thirdFailedAttemptReviewSection.loading}
+        rows={thirdFailedAttemptReviewSection.result}
+      />
+      <ReviewSection
+        heading={`Fourth Failed Attempt: ${fourthFailedAttemptDate}`}
+        loading={fourthFailedAttemptReviewSection.loading}
+        rows={fourthFailedAttemptReviewSection.result}
+      />
+      <Textarea
+        name="other-notes"
+        label={{
+          children: "Add any additional notes if necessary.",
+        }}
+        onChange={(textValue: string): void => setOtherNotes(textValue)}
+        value={otherNotes}
+        rows={4}
+      />
+
+      <SubmitButton
+        disabled={!processRef || !processDatabase.result}
+        onSubmit={async (): Promise<boolean> => {
+          if (!processRef || !processDatabase.result) {
+            return false;
+          }
+
+          await processDatabase.result.transaction(
+            ["unableToEnter"],
+            async (stores) => {
+              const unableToEnter =
+                (await stores.unableToEnter.get(processRef)) ||
+                ({} as ProcessDatabaseSchema["schema"]["unableToEnter"]["value"]);
+
+              await stores.unableToEnter.put(processRef, {
+                ...unableToEnter,
+                otherNotes,
+              });
+            },
+            TransactionMode.ReadWrite
+          );
+
+          return true;
+        }}
+      />
+    </MainLayout>
+  );
+};
+
+export default UnableToEnterReviewPage;

--- a/steps/PageSlugs.ts
+++ b/steps/PageSlugs.ts
@@ -68,6 +68,7 @@ enum PageSlugs {
   SecondFailedAttempt = "second-failed-attempt",
   ThirdFailedAttempt = "third-failed-attempt",
   FourthFailedAttempt = "fourth-failed-attempt",
+  UnableToEnterReview = "unable-to-enter-review",
 }
 
 const slugs: {
@@ -122,6 +123,7 @@ const slugs: {
   "second-failed-attempt": true,
   "third-failed-attempt": true,
   "fourth-failed-attempt": true,
+  "unable-to-enter-review": false,
 };
 
 export const stepSlugs = Object.entries(slugs)

--- a/steps/PageTitles.ts
+++ b/steps/PageTitles.ts
@@ -65,6 +65,7 @@ enum PageTitles {
   SecondFailedAttempt = "Second failed attempt",
   ThirdFailedAttempt = "Third failed attempt",
   FourthFailedAttempt = "Fourth failed attempt",
+  UnableToEnterReview = "Unable to enter review",
 }
 
 export default PageTitles;

--- a/steps/unable-to-enter/first-failed-attempt.tsx
+++ b/steps/unable-to-enter/first-failed-attempt.tsx
@@ -16,17 +16,46 @@ import {
 import { Checkboxes, CheckboxesProps } from "../../components/Checkboxes";
 import { makeSubmit } from "../../components/makeSubmit";
 import failedAttemptReasonCheckboxes from "../../helpers/failedAttemptReasonCheckboxes";
+import { getCheckboxLabelsFromValues } from "../../helpers/getCheckboxLabelsFromValues";
 import keyFromSlug from "../../helpers/keyFromSlug";
 import { persistUnableToEnterDate } from "../../helpers/persistUnableToEnterDate";
+import ProcessStepDefinition from "../../helpers/ProcessStepDefinition";
 import ProcessDatabaseSchema, {
   UnableToEnterPropertyNames,
 } from "../../storage/ProcessDatabaseSchema";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
-const step = {
+const questions = {
+  "why-unable-to-enter":
+    "Why were you unable to enter the property? Did you observe anything of concern?",
+};
+
+const step: ProcessStepDefinition<ProcessDatabaseSchema, "unableToEnter"> = {
   title: PageTitles.FirstFailedAttempt,
   heading: "Unable to enter the property",
+  review: {
+    rows: [
+      {
+        label: questions["why-unable-to-enter"],
+        values: {
+          "why-unable-to-enter": {
+            renderValue(reasons: string[]): React.ReactNode {
+              return getCheckboxLabelsFromValues(
+                failedAttemptReasonCheckboxes,
+                reasons
+              );
+            },
+          },
+          "first-attempt-notes": {
+            renderValue(firstAttemptNotes: string): React.ReactNode {
+              return firstAttemptNotes;
+            },
+          },
+        },
+      },
+    ],
+  },
   step: {
     slug: PageSlugs.FirstFailedAttempt,
     nextSlug: PageSlugs.Pause,
@@ -62,8 +91,7 @@ const step = {
             name: "why-unable-to-enter",
             legend: (
               <FieldsetLegend>
-                Why were you unable to enter the property? Did you observe
-                anything of concern?
+                {questions["why-unable-to-enter"]}
               </FieldsetLegend>
             ) as React.ReactNode,
             checkboxes: failedAttemptReasonCheckboxes,

--- a/steps/unable-to-enter/fourth-failed-attempt.tsx
+++ b/steps/unable-to-enter/fourth-failed-attempt.tsx
@@ -18,20 +18,69 @@ import { makeSubmit } from "../../components/makeSubmit";
 import PreviousAttemptsAnnouncement from "../../components/PreviousAttemptsAnnouncement";
 import SingleCheckbox from "../../components/SingleCheckbox";
 import failedAttemptReasonCheckboxes from "../../helpers/failedAttemptReasonCheckboxes";
+import { getCheckboxLabelsFromValues } from "../../helpers/getCheckboxLabelsFromValues";
 import keyFromSlug from "../../helpers/keyFromSlug";
 import { persistUnableToEnterDate } from "../../helpers/persistUnableToEnterDate";
+import ProcessStepDefinition from "../../helpers/ProcessStepDefinition";
 import ProcessDatabaseSchema, {
   UnableToEnterPropertyNames,
 } from "../../storage/ProcessDatabaseSchema";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
-const step = {
+const questions = {
+  "why-unable-to-enter":
+    "Why were you unable to enter the property? Did you observe anything of concern?",
+  "what-action": "What did you do?",
+};
+
+const step: ProcessStepDefinition<ProcessDatabaseSchema, "unableToEnter"> = {
   title: PageTitles.FourthFailedAttempt,
   heading: "Unable to enter the property",
+  review: {
+    rows: [
+      {
+        label: questions["why-unable-to-enter"],
+        values: {
+          "why-unable-to-enter": {
+            renderValue(reasons: string[]): React.ReactNode {
+              return getCheckboxLabelsFromValues(
+                failedAttemptReasonCheckboxes,
+                reasons
+              );
+            },
+          },
+          "fourth-attempt-notes": {
+            renderValue(fourthAttemptNotes: string): React.ReactNode {
+              return fourthAttemptNotes;
+            },
+          },
+        },
+      },
+      {
+        label: "Actions",
+        values: {
+          "fraud-reminder": {
+            renderValue(created: boolean): React.ReactNode {
+              if (created) {
+                return "Created reminder to start fraud investigation";
+              }
+            },
+          },
+          "fraud-letter-reminder": {
+            renderValue(created: boolean): React.ReactNode {
+              if (created) {
+                return "Created reminder to send fraud investigation letter (T&HC3)";
+              }
+            },
+          },
+        },
+      },
+    ],
+  },
   step: {
     slug: PageSlugs.FourthFailedAttempt,
-    nextSlug: PageSlugs.Pause,
+    nextSlug: PageSlugs.UnableToEnterReview,
     submit: (nextSlug?: string): ReturnType<typeof makeSubmit> =>
       makeSubmit([
         {
@@ -71,8 +120,7 @@ const step = {
             name: "why-unable-to-enter",
             legend: (
               <FieldsetLegend>
-                Why were you unable to enter the property? Did you observe
-                anything of concern?
+                {questions["why-unable-to-enter"]}
               </FieldsetLegend>
             ) as React.ReactNode,
             checkboxes: failedAttemptReasonCheckboxes,

--- a/steps/unable-to-enter/second-failed-attempt.tsx
+++ b/steps/unable-to-enter/second-failed-attempt.tsx
@@ -17,17 +17,46 @@ import { Checkboxes, CheckboxesProps } from "../../components/Checkboxes";
 import { makeSubmit } from "../../components/makeSubmit";
 import PreviousAttemptsAnnouncement from "../../components/PreviousAttemptsAnnouncement";
 import failedAttemptReasonCheckboxes from "../../helpers/failedAttemptReasonCheckboxes";
+import { getCheckboxLabelsFromValues } from "../../helpers/getCheckboxLabelsFromValues";
 import keyFromSlug from "../../helpers/keyFromSlug";
 import { persistUnableToEnterDate } from "../../helpers/persistUnableToEnterDate";
+import ProcessStepDefinition from "../../helpers/ProcessStepDefinition";
 import PageSlugs from "../../steps/PageSlugs";
 import PageTitles from "../../steps/PageTitles";
 import ProcessDatabaseSchema, {
   UnableToEnterPropertyNames,
 } from "../../storage/ProcessDatabaseSchema";
 
-const step = {
+const questions = {
+  "why-unable-to-enter":
+    "Why were you unable to enter the property? Did you observe anything of concern?",
+};
+
+const step: ProcessStepDefinition<ProcessDatabaseSchema, "unableToEnter"> = {
   title: PageTitles.SecondFailedAttempt,
   heading: "Unable to enter the property",
+  review: {
+    rows: [
+      {
+        label: questions["why-unable-to-enter"],
+        values: {
+          "why-unable-to-enter": {
+            renderValue(reasons: string[]): React.ReactNode {
+              return getCheckboxLabelsFromValues(
+                failedAttemptReasonCheckboxes,
+                reasons
+              );
+            },
+          },
+          "second-attempt-notes": {
+            renderValue(secondAttemptNotes: string): React.ReactNode {
+              return secondAttemptNotes;
+            },
+          },
+        },
+      },
+    ],
+  },
   step: {
     slug: PageSlugs.SecondFailedAttempt,
     nextSlug: PageSlugs.Pause,
@@ -70,8 +99,7 @@ const step = {
             name: "why-unable-to-enter",
             legend: (
               <FieldsetLegend>
-                Why were you unable to enter the property? Did you observe
-                anything of concern?
+                {questions["why-unable-to-enter"]}
               </FieldsetLegend>
             ) as React.ReactNode,
             checkboxes: failedAttemptReasonCheckboxes,

--- a/steps/unable-to-enter/third-failed-attempt.tsx
+++ b/steps/unable-to-enter/third-failed-attempt.tsx
@@ -19,17 +19,72 @@ import PreviousAttemptsAnnouncement from "../../components/PreviousAttemptsAnnou
 import SingleCheckbox from "../../components/SingleCheckbox";
 import failedAttemptActionCheckboxes from "../../helpers/failedAttemptActionCheckboxes";
 import failedAttemptReasonCheckboxes from "../../helpers/failedAttemptReasonCheckboxes";
+import { getCheckboxLabelsFromValues } from "../../helpers/getCheckboxLabelsFromValues";
 import keyFromSlug from "../../helpers/keyFromSlug";
 import { persistUnableToEnterDate } from "../../helpers/persistUnableToEnterDate";
+import ProcessStepDefinition from "../../helpers/ProcessStepDefinition";
 import ProcessDatabaseSchema, {
   UnableToEnterPropertyNames,
 } from "../../storage/ProcessDatabaseSchema";
 import PageSlugs from "../PageSlugs";
 import PageTitles from "../PageTitles";
 
-const step = {
+const questions = {
+  "why-unable-to-enter":
+    "Why were you unable to enter the property? Did you observe anything of concern?",
+  "what-action": "What did you do?",
+};
+
+const step: ProcessStepDefinition<ProcessDatabaseSchema, "unableToEnter"> = {
   title: PageTitles.ThirdFailedAttempt,
   heading: "Unable to enter the property",
+  review: {
+    rows: [
+      {
+        label: questions["why-unable-to-enter"],
+        values: {
+          "why-unable-to-enter": {
+            renderValue(reasons: string[]): React.ReactNode {
+              return getCheckboxLabelsFromValues(
+                failedAttemptReasonCheckboxes,
+                reasons
+              );
+            },
+          },
+          "third-attempt-notes": {
+            renderValue(thirdAttemptNotes: string): React.ReactNode {
+              return thirdAttemptNotes;
+            },
+          },
+        },
+      },
+      {
+        label: questions["what-action"],
+        values: {
+          "what-action": {
+            renderValue(actions: string[]): React.ReactNode {
+              return getCheckboxLabelsFromValues(
+                failedAttemptActionCheckboxes,
+                actions
+              );
+            },
+          },
+        },
+      },
+      {
+        label: "Actions",
+        values: {
+          "appointment-letter-reminder": {
+            renderValue(created: boolean): React.ReactNode {
+              if (created) {
+                return "Created reminder to send appointment letter (T&HC2)";
+              }
+            },
+          },
+        },
+      },
+    ],
+  },
   step: {
     slug: PageSlugs.ThirdFailedAttempt,
     nextSlug: PageSlugs.Pause,
@@ -72,8 +127,7 @@ const step = {
             name: "why-unable-to-enter",
             legend: (
               <FieldsetLegend>
-                Why were you unable to enter the property? Did you observe
-                anything of concern?
+                {questions["why-unable-to-enter"]}
               </FieldsetLegend>
             ) as React.ReactNode,
             checkboxes: failedAttemptReasonCheckboxes,
@@ -97,7 +151,7 @@ const step = {
           props: {
             name: "what-action",
             legend: (
-              <FieldsetLegend>What did you do?</FieldsetLegend>
+              <FieldsetLegend>{questions["what-action"]}</FieldsetLegend>
             ) as React.ReactNode,
             checkboxes: failedAttemptActionCheckboxes,
           } as CheckboxesProps,

--- a/storage/ProcessDatabaseSchema.ts
+++ b/storage/ProcessDatabaseSchema.ts
@@ -251,6 +251,7 @@ type ProcessDatabaseSchema = NamedSchema<
           needsFraudInvestigationReminder: boolean;
           needsFraudInvestigationLetterReminder: boolean;
         };
+        otherNotes: string;
       };
     };
 


### PR DESCRIPTION
This is accessible from the fourth failed attempt to visit page, and takes the user to the submit page when done. 

It's slightly different from the design on Balsamiq, as we wanted to use our existing components to get this to render easily.

I'm wondering if we should link to this page on the main "outside" page where "unable to enter" is greyed out if the user navigates back after filling in the fourth attempt page (although this may not be a real user journey).
