### PR TITLE
MT3-391 #ready-for-test Tidy up sections logic

### DIFF
--- a/components/TaskList.tsx
+++ b/components/TaskList.tsx
@@ -1,7 +1,6 @@
 import { Link, List, Tag } from "lbh-frontend-react/components";
 import querystring from "querystring";
 import React from "react";
-import PropTypes, { PropTypesTypes } from "../helpers/PropTypes";
 
 export enum TaskListStatus {
   Unavailable = "unavailable",
@@ -24,7 +23,7 @@ export interface TaskListItem {
   /**
    * The status to display against the task.
    */
-  status: TaskListStatus;
+  status: TaskListStatus | undefined;
 
   /**
    * @ignore
@@ -53,7 +52,7 @@ export const TaskList: React.FunctionComponent<Props> = (props) => {
           return (
             <>
               <span>{name}</span>
-              {status !== TaskListStatus.Unavailable && (
+              {status && status !== TaskListStatus.Unavailable && (
                 <span>
                   {status !== TaskListStatus.NotStarted && <Tag>{status}</Tag>}
                   <Link href={href} data-testid={testId}>
@@ -92,18 +91,3 @@ export const TaskList: React.FunctionComponent<Props> = (props) => {
 };
 
 TaskList.displayName = "TaskList";
-
-TaskList.propTypes = {
-  items: PropTypes.arrayOf(
-    PropTypes.exact({
-      name: PropTypes.string.isRequired,
-      url: PropTypes.shape({
-        pathname: PropTypes.string.isRequired,
-        query: PropTypes.object,
-      }).isRequired,
-      status: (PropTypes.string as PropTypesTypes.Requireable<TaskListStatus>)
-        .isRequired,
-      "data-testid": PropTypes.string,
-    }).isRequired
-  ).isRequired,
-};

--- a/helpers/yesNoNotPresentRadio.ts
+++ b/helpers/yesNoNotPresentRadio.ts
@@ -1,3 +1,8 @@
+export const tenantNotPresent = {
+  label: "Tenant not present",
+  value: "tenant not present",
+};
+
 export default [
   {
     label: "Yes",
@@ -7,8 +12,5 @@ export default [
     label: "No",
     value: "no",
   },
-  {
-    label: "Tenant not present",
-    value: "tenant not present",
-  },
+  tenantNotPresent,
 ];

--- a/pages/thc/[processRef]/sections.tsx
+++ b/pages/thc/[processRef]/sections.tsx
@@ -2,15 +2,341 @@ import { Paragraph } from "lbh-frontend-react/components";
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 import React from "react";
+import { StoreValue } from "remultiform/database";
 import { TaskList, TaskListStatus } from "../../../components/TaskList";
 import { TenancySummary } from "../../../components/TenancySummary";
 import getProcessRef from "../../../helpers/getProcessRef";
 import useDataValue from "../../../helpers/useDataValue";
 import useValidateData from "../../../helpers/useValidateData";
+import { tenantNotPresent } from "../../../helpers/yesNoNotPresentRadio";
 import MainLayout from "../../../layouts/MainLayout";
 import PageSlugs, { urlObjectForSlug } from "../../../steps/PageSlugs";
 import PageTitles from "../../../steps/PageTitles";
+import ExternalDatabaseSchema from "../../../storage/ExternalDatabaseSchema";
+import ProcessDatabaseSchema, {
+  ProcessRef,
+} from "../../../storage/ProcessDatabaseSchema";
 import Storage from "../../../storage/Storage";
+
+interface Status {
+  loading: boolean;
+  status: TaskListStatus | undefined;
+  errors: Error[] | undefined;
+}
+
+const useIdAndResidencyStatus = (
+  processRef: ProcessRef | undefined,
+  residentData:
+    | StoreValue<ExternalDatabaseSchema["schema"], "residents">
+    | undefined
+): Status => {
+  const tenantsPresent = useDataValue(
+    Storage.ProcessContext,
+    "tenantsPresent",
+    processRef,
+    (values) => (processRef !== undefined ? values[processRef] : undefined)
+  );
+
+  const allTenantIds = residentData?.tenants.map((tenant) => tenant.id);
+  const presentTenantIds = tenantsPresent.result;
+
+  const started = useValidateData(
+    Storage.ProcessContext,
+    ["tenantsPresent"],
+    processRef,
+    (valueSets) => {
+      const tenantsPresentSet = valueSets.tenantsPresent;
+
+      if (tenantsPresentSet === undefined || processRef === undefined) {
+        return false;
+      }
+
+      const tenantsPresent = tenantsPresentSet[processRef];
+
+      const completedFirstStep = tenantsPresent !== undefined;
+
+      return completedFirstStep;
+    }
+  );
+
+  const idCompleted = useValidateData(
+    Storage.ResidentContext,
+    ["id"],
+    presentTenantIds,
+    (valueSets) => {
+      const idSet = valueSets.id;
+
+      if (idSet === undefined) {
+        return false;
+      }
+
+      const allCompletedRequiredStep =
+        Object.values(idSet).length === presentTenantIds?.length &&
+        Object.values(idSet).every(
+          (id) => id?.type && id.type !== tenantNotPresent.value
+        );
+
+      return allCompletedRequiredStep;
+    }
+  );
+
+  const residencyCompleted = useValidateData(
+    Storage.ResidentContext,
+    ["residency"],
+    allTenantIds,
+    (valueSets) => {
+      const residencySet = valueSets.residency;
+
+      if (residencySet === undefined) {
+        return false;
+      }
+
+      const allCompletedRequiredStep =
+        Object.values(residencySet).length === allTenantIds?.length &&
+        Object.values(residencySet).every((residency) => residency?.type);
+
+      return allCompletedRequiredStep;
+    }
+  );
+
+  const loading =
+    tenantsPresent.loading ||
+    started.loading ||
+    idCompleted.loading ||
+    residencyCompleted.loading;
+
+  const errors = [];
+
+  if (tenantsPresent.error) {
+    errors.push(tenantsPresent.error);
+  }
+
+  if (started.error) {
+    errors.push(started.error);
+  }
+
+  if (idCompleted.error) {
+    errors.push(idCompleted.error);
+  }
+
+  if (residencyCompleted.error) {
+    errors.push(residencyCompleted.error);
+  }
+
+  // Note that we don't check the last step like we do for other sections, as
+  // no step after residency creates an empty object when submitting without
+  // answering any questions.
+  return {
+    loading,
+    status: loading
+      ? undefined
+      : started.result
+      ? idCompleted.result && residencyCompleted.result
+        ? TaskListStatus.Completed
+        : TaskListStatus.Started
+      : TaskListStatus.NotStarted,
+    errors: errors.length > 0 ? errors : undefined,
+  };
+};
+
+const useHouseholdStatus = (processRef: ProcessRef | undefined): Status => {
+  const started = useValidateData(
+    Storage.ProcessContext,
+    ["household"],
+    processRef,
+    (valueSets) => {
+      const householdSet = valueSets.household;
+
+      if (householdSet === undefined || processRef === undefined) {
+        return false;
+      }
+
+      const household = householdSet[processRef];
+      const completedFirstStep = household?.documents !== undefined;
+
+      return completedFirstStep;
+    }
+  );
+
+  const completed = useValidateData(
+    Storage.ProcessContext,
+    ["household"],
+    processRef,
+    (valueSets) => {
+      const householdSet = valueSets.household;
+
+      if (householdSet === undefined || processRef === undefined) {
+        return false;
+      }
+
+      const household = householdSet[processRef];
+      const completedLastStep = household?.otherProperty !== undefined;
+
+      return completedLastStep;
+    }
+  );
+
+  const loading = started.loading || completed.loading;
+
+  const errors = [];
+
+  if (started.error) {
+    errors.push(started.error);
+  }
+
+  if (completed.error) {
+    errors.push(completed.error);
+  }
+
+  return {
+    loading,
+    status: loading
+      ? undefined
+      : started.result
+      ? completed.result
+        ? TaskListStatus.Completed
+        : TaskListStatus.Started
+      : TaskListStatus.NotStarted,
+    errors: errors.length > 0 ? errors : undefined,
+  };
+};
+
+const usePropertyInspectionStatus = (
+  processRef: ProcessRef | undefined
+): Status => {
+  const started = useValidateData(
+    Storage.ProcessContext,
+    ["property"],
+    processRef,
+    (valueSets) => {
+      const propertySet = valueSets.property;
+
+      if (propertySet === undefined || processRef === undefined) {
+        return false;
+      }
+
+      const property = propertySet[processRef];
+      const completedFirstStep = property?.rooms !== undefined;
+
+      return completedFirstStep;
+    }
+  );
+
+  const completed = useValidateData(
+    Storage.ProcessContext,
+    ["property"],
+    processRef,
+    (valueSets) => {
+      const propertySet = valueSets.property;
+
+      if (propertySet === undefined || processRef === undefined) {
+        return false;
+      }
+
+      const property = propertySet[processRef];
+      const completedLastStep = property?.otherComments !== undefined;
+
+      return completedLastStep !== undefined;
+    }
+  );
+
+  const loading = started.loading || completed.loading;
+
+  const errors = [];
+
+  if (started.error) {
+    errors.push(started.error);
+  }
+
+  if (completed.error) {
+    errors.push(completed.error);
+  }
+
+  return {
+    loading,
+    status: loading
+      ? undefined
+      : started.result
+      ? completed.result
+        ? TaskListStatus.Completed
+        : TaskListStatus.Started
+      : TaskListStatus.NotStarted,
+    errors: errors.length > 0 ? errors : undefined,
+  };
+};
+
+const useWellbeingSupportStatus = (
+  processRef: ProcessRef | undefined
+): Status => {
+  const started = useValidateData(
+    Storage.ProcessContext,
+    ["homeCheck"],
+    processRef,
+    (valueSets) => {
+      const homeCheckSet = valueSets.homeCheck;
+
+      if (homeCheckSet === undefined || processRef === undefined) {
+        return false;
+      }
+
+      const homeCheck = homeCheckSet[processRef];
+      const completedFirstStep = homeCheck !== undefined;
+
+      return completedFirstStep;
+    }
+  );
+
+  const completed = useValidateData(
+    Storage.ProcessContext,
+    ["homeCheck", "supportNeeds"],
+    processRef,
+    (valueSets) => {
+      const homeCheckSet = valueSets.homeCheck;
+      const supportNeedsSet = valueSets.supportNeeds;
+
+      if (
+        homeCheckSet === undefined ||
+        supportNeedsSet === undefined ||
+        processRef === undefined
+      ) {
+        return false;
+      }
+
+      const homeCheck = homeCheckSet[processRef] as
+        | StoreValue<ProcessDatabaseSchema["schema"], "homeCheck">
+        | undefined;
+      const supportNeeds = supportNeedsSet[processRef];
+      const completedLastStep =
+        homeCheck?.value === "no" || supportNeeds !== undefined;
+
+      return completedLastStep;
+    }
+  );
+
+  const loading = started.loading || completed.loading;
+
+  const errors = [];
+
+  if (started.error) {
+    errors.push(started.error);
+  }
+
+  if (completed.error) {
+    errors.push(completed.error);
+  }
+
+  return {
+    loading: started.loading || completed.loading,
+    status: loading
+      ? undefined
+      : started.result
+      ? completed.result
+        ? TaskListStatus.Completed
+        : TaskListStatus.Started
+      : TaskListStatus.NotStarted,
+    errors: errors.length > 0 ? errors : undefined,
+  };
+};
 
 export const SectionsPage: NextPage = () => {
   const router = useRouter();
@@ -29,112 +355,14 @@ export const SectionsPage: NextPage = () => {
     processRef,
     (values) => (processRef ? values[processRef] : undefined)
   );
-  const idAndResidencyStarted = useValidateData(
-    Storage.ProcessContext,
-    ["tenantsPresent"],
-    processRef
-  );
-  const idAndResidencyComplete = useValidateData(
-    Storage.ResidentContext,
-    ["id", "residency", "photo", "nextOfKin", "carer"],
-    residentData.result?.tenants.map((tenant) => tenant.id)
-  );
-  const householdStarted = useValidateData(
-    Storage.ProcessContext,
-    ["household"],
+
+  const idAndResidencyStatus = useIdAndResidencyStatus(
     processRef,
-    (valueSets) => {
-      const householdSet = valueSets.household;
-
-      if (householdSet === undefined || processRef === undefined) {
-        return false;
-      }
-
-      const household = householdSet[processRef];
-
-      return household !== undefined && household.documents !== undefined;
-    }
+    residentData.result
   );
-  const householdComplete = useValidateData(
-    Storage.ProcessContext,
-    ["household"],
-    processRef
-  );
-  const propertyInspectionStarted = useValidateData(
-    Storage.ProcessContext,
-    ["property"],
-    processRef,
-    (valueSets) => {
-      const propertySet = valueSets.property;
-
-      if (propertySet === undefined || processRef === undefined) {
-        return false;
-      }
-
-      const property = propertySet[processRef];
-
-      return property !== undefined && property.rooms !== undefined;
-    }
-  );
-  const propertyInspectionComplete = useValidateData(
-    Storage.ProcessContext,
-    ["property"],
-    processRef,
-    (valueSets) => {
-      const propertySet = valueSets.property;
-
-      if (propertySet === undefined || processRef === undefined) {
-        return false;
-      }
-
-      const property = propertySet[processRef];
-
-      return (
-        property !== undefined &&
-        Object.entries(property).every(
-          ([key, value]) => key === "outside" || value !== undefined
-        )
-      );
-    }
-  );
-  const wellbeingSupportStarted = useValidateData(
-    Storage.ProcessContext,
-    ["homeCheck"],
-    processRef,
-    (valueSets) => {
-      const homeCheckSet = valueSets.homeCheck;
-
-      if (homeCheckSet === undefined || processRef === undefined) {
-        return false;
-      }
-
-      const homeCheck = homeCheckSet[processRef];
-
-      return homeCheck !== undefined;
-    }
-  );
-  const wellbeingSupportComplete = useValidateData(
-    Storage.ProcessContext,
-    ["homeCheck", "healthConcerns", "disability"],
-    processRef,
-    (valueSets) => {
-      const homeCheckSet = valueSets.homeCheck;
-
-      if (homeCheckSet === undefined || processRef === undefined) {
-        return false;
-      }
-
-      const homeCheck = homeCheckSet[processRef];
-
-      return (
-        homeCheck !== undefined &&
-        (homeCheck.value === "no" ||
-          Object.values(valueSets).every((valueSet) =>
-            Object.values(valueSet || {}).every((value) => value !== undefined)
-          ))
-      );
-    }
-  );
+  const householdStatus = useHouseholdStatus(processRef);
+  const propertyInspectionStatus = usePropertyInspectionStatus(processRef);
+  const wellbeingSupportStatus = useWellbeingSupportStatus(processRef);
 
   return (
     <MainLayout
@@ -167,12 +395,12 @@ export const SectionsPage: NextPage = () => {
         }}
       />
 
-      {idAndResidencyComplete.loading ? (
+      {idAndResidencyStatus.loading ? (
         <Paragraph>Checking process status...</Paragraph>
       ) : (
         <>
           <Paragraph>
-            {idAndResidencyComplete.result
+            {idAndResidencyStatus.status === TaskListStatus.Completed
               ? "Please complete the remaining sections."
               : "To begin the check, verify the tenant's ID and proof of residency."}
           </Paragraph>
@@ -182,53 +410,37 @@ export const SectionsPage: NextPage = () => {
               {
                 name: "ID, residency, and tenant information",
                 url: urlObjectForSlug(router, PageSlugs.PresentForCheck),
-                status: idAndResidencyComplete.result
-                  ? TaskListStatus.Completed
-                  : idAndResidencyStarted.result
-                  ? TaskListStatus.Started
-                  : TaskListStatus.NotStarted,
+                status: idAndResidencyStatus.status,
               },
               {
                 name: "Household",
                 url: urlObjectForSlug(router, PageSlugs.Household),
-                status: idAndResidencyComplete.result
-                  ? householdComplete.result
-                    ? TaskListStatus.Completed
-                    : householdStarted.result
-                    ? TaskListStatus.Started
-                    : TaskListStatus.NotStarted
-                  : TaskListStatus.Unavailable,
+                status:
+                  idAndResidencyStatus.status === TaskListStatus.Completed
+                    ? householdStatus.status
+                    : TaskListStatus.Unavailable,
               },
               {
                 name: "Property inspection",
                 url: urlObjectForSlug(router, PageSlugs.Rooms),
-                status: idAndResidencyComplete.result
-                  ? propertyInspectionComplete.result
-                    ? TaskListStatus.Completed
-                    : propertyInspectionStarted.result
-                    ? TaskListStatus.Started
-                    : TaskListStatus.NotStarted
-                  : TaskListStatus.Unavailable,
+                status:
+                  idAndResidencyStatus.status === TaskListStatus.Completed
+                    ? propertyInspectionStatus.status
+                    : TaskListStatus.Unavailable,
               },
               {
                 name: "Wellbeing support",
                 url: urlObjectForSlug(router, PageSlugs.HomeCheck),
-                status: idAndResidencyComplete.result
-                  ? wellbeingSupportComplete.result
-                    ? TaskListStatus.Completed
-                    : wellbeingSupportStarted.result
-                    ? TaskListStatus.Started
-                    : TaskListStatus.NotStarted
-                  : TaskListStatus.Unavailable,
+                status:
+                  idAndResidencyStatus.status === TaskListStatus.Completed
+                    ? wellbeingSupportStatus.status
+                    : TaskListStatus.Unavailable,
               },
               {
                 name: "Review and submit",
                 url: urlObjectForSlug(router, PageSlugs.Review),
                 status:
-                  idAndResidencyComplete.result &&
-                  householdComplete.result &&
-                  propertyInspectionComplete.result &&
-                  wellbeingSupportComplete.result
+                  idAndResidencyStatus.status === TaskListStatus.Completed
                     ? TaskListStatus.NotStarted
                     : TaskListStatus.Unavailable,
               },

--- a/pages/thc/[processRef]/verify.tsx
+++ b/pages/thc/[processRef]/verify.tsx
@@ -17,6 +17,7 @@ import slugWithId from "../../../helpers/slugWithId";
 import urlsForRouter from "../../../helpers/urlsForRouter";
 import useDataSet from "../../../helpers/useDataSet";
 import useDataValue from "../../../helpers/useDataValue";
+import { tenantNotPresent } from "../../../helpers/yesNoNotPresentRadio";
 import MainLayout from "../../../layouts/MainLayout";
 import PageSlugs, { urlObjectForSlug } from "../../../steps/PageSlugs";
 import PageTitles from "../../../steps/PageTitles";
@@ -64,7 +65,7 @@ export const VerifyPage: NextPage = () => {
       id:
         idData.result &&
         idData.result[tenant.id]?.type &&
-        idData.result[tenant.id]?.type !== "tenant not present"
+        idData.result[tenant.id]?.type !== tenantNotPresent.value
           ? true
           : tenantsPresent.result?.includes(tenant.id)
           ? false

--- a/steps/id-and-residency/id.tsx
+++ b/steps/id-and-residency/id.tsx
@@ -19,6 +19,7 @@ import { getRadioLabelFromValue } from "../../helpers/getRadioLabelFromValue";
 import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessStepDefinition from "../../helpers/ProcessStepDefinition";
 import slugForRepeatingStep from "../../helpers/slugForRepeatingStep";
+import { tenantNotPresent } from "../../helpers/yesNoNotPresentRadio";
 import { Notes } from "../../storage/DatabaseSchema";
 import ResidentDatabaseSchema from "../../storage/ResidentDatabaseSchema";
 import Storage from "../../storage/Storage";
@@ -50,10 +51,7 @@ const idTypeRadios = [
     label: "Unable to verify ID",
     value: "no id",
   },
-  {
-    label: "Tenant not present",
-    value: "tenant not present",
-  },
+  tenantNotPresent,
 ];
 
 const step: ProcessStepDefinition<ResidentDatabaseSchema, "id"> = {

--- a/steps/id-and-residency/tenant-photo.tsx
+++ b/steps/id-and-residency/tenant-photo.tsx
@@ -20,7 +20,9 @@ import { ReviewNotes } from "../../components/ReviewNotes";
 import keyFromSlug from "../../helpers/keyFromSlug";
 import ProcessStepDefinition from "../../helpers/ProcessStepDefinition";
 import slugForRepeatingStep from "../../helpers/slugForRepeatingStep";
-import yesNoNotPresentRadio from "../../helpers/yesNoNotPresentRadio";
+import yesNoNotPresentRadio, {
+  tenantNotPresent,
+} from "../../helpers/yesNoNotPresentRadio";
 import { Notes } from "../../storage/DatabaseSchema";
 import ResidentDatabaseSchema from "../../storage/ResidentDatabaseSchema";
 import Storage from "../../storage/Storage";
@@ -42,7 +44,7 @@ const step: ProcessStepDefinition<ResidentDatabaseSchema, "photo"> = {
                 ? "Tenant agreed to be photographed"
                 : willing === "no"
                 ? "Tenant does not want to be photographed"
-                : willing === "tenant not present"
+                : willing === tenantNotPresent.value
                 ? "Tenant not present"
                 : undefined;
             },


### PR DESCRIPTION
- Only require "required" ID & Residency steps to be completed before marking step as "complete"
- No longer marks Property Inspection step as "complete" on first load (by ignoring previous step `/outside-property` values)
- Allow user to access Review page link after ID & Residency step