### PR TITLE
MT3-735: remove loading headline once the page is finished loading

### DIFF
--- a/pages/thc/[processRef]/loading.tsx
+++ b/pages/thc/[processRef]/loading.tsx
@@ -444,7 +444,6 @@ export const LoadingPage: NextPage = () => {
   const loading =
     processDataSyncStatus.loading ||
     extraResults.some((result) => result.loading);
-  console.log("LoadingPage:NextPage -> loading", loading);
 
   const errored =
     Boolean(processDataSyncStatus.error) ||

--- a/pages/thc/[processRef]/loading.tsx
+++ b/pages/thc/[processRef]/loading.tsx
@@ -444,6 +444,8 @@ export const LoadingPage: NextPage = () => {
   const loading =
     processDataSyncStatus.loading ||
     extraResults.some((result) => result.loading);
+  console.log("LoadingPage:NextPage -> loading", loading);
+
   const errored =
     Boolean(processDataSyncStatus.error) ||
     extraResults.some((result) => result.error);
@@ -529,7 +531,8 @@ export const LoadingPage: NextPage = () => {
         </ErrorMessage>
       )}
 
-      <Heading level={HeadingLevels.H2}>Loading</Heading>
+      {loading && <Heading level={HeadingLevels.H2}>Loading</Heading>}
+
       <Paragraph>
         {isInManagerStage || isInClosedStage
           ? "The system is fetching the information you need for this process."


### PR DESCRIPTION
<!--
  Is this related to a ticket in Jira? If so, add Smart Commit commands to the
  PR title to be automatically included in the merge commit if the PR is merged.

  For example:

  MT3-221 #ready-for-test #comment Create a pull request template

  https://confluence.atlassian.com/fisheye/using-smart-commits-960155400.html
  -->

MT3-735: Fix Loading state on Loading page. 

# What?

There was a heading that said "Loading" that was being shown even after the loading was complete. It was updated to only show when the page was in a loading state.

<!--
  What new features or changes does this pull request contain?

  Include before and after screenshots, if appropriate.
  -->

# Why?

<!--
  What motivates these changes?

  Include any user stories driving this feature, if appropriate.
  -->

# Notes

<!--
  Is there anything about the implementation worth calling out to reviewers?
  -->

# Next steps

<!--
  Is there any follow up work that needs to be done?

  Consider using a checklist, for example:

  - [ ] do something
  - [ ] do something else
  -->
