### PR TITLE
feat: MT3-742 separate manager comments

### DIFF
--- a/pages/thc/[processRef]/closed-review.tsx
+++ b/pages/thc/[processRef]/closed-review.tsx
@@ -46,19 +46,19 @@ const ReviewPage: NextPage = () => {
   const processDatabase = useDatabase(Storage.ProcessContext);
   const isInManagerStage = isManager(router);
 
-  const managerComment = useDataValue(
+  const managerComments = useDataValue(
     Storage.ProcessContext,
-    "managerComment",
+    "managerComments",
     processRef,
     (values) => (processRef ? values[processRef] : undefined)
   );
 
-  const [managerCommentState, setManagerCommentState] = useState("");
+  const [managerComment, setManagerComment] = useState<string>("");
   useEffect(() => {
-    if (managerComment.result !== undefined) {
-      setManagerCommentState(managerComment.result);
+    if (managerComments.result !== undefined) {
+      setManagerComment(managerComments.result.closedReview);
     }
-  }, [managerComment.result]);
+  }, [managerComments.result]);
 
   const tenants = useDataValue(
     Storage.ExternalContext,
@@ -268,9 +268,9 @@ const ReviewPage: NextPage = () => {
               <Heading level={HeadingLevels.H2}>Manager&apos;s comment</Heading>
             ),
           }}
-          value={managerCommentState}
+          value={managerComment}
           rows={4}
-          onChange={(value): void => setManagerCommentState(value)}
+          onChange={(value): void => setManagerComment(value)}
         />
       )}
       <SubmitButton
@@ -280,11 +280,22 @@ const ReviewPage: NextPage = () => {
           }
 
           if (isInManagerStage) {
-            // FIXME: This will overwrite the existing "managerComment" if there is one
+            const comments = Object.assign(
+              {
+                closedReview: "",
+                managerReview: "",
+                unableToEnterClosedReview: "",
+                unableToEnterManagerReview: "",
+              },
+              managerComments.result,
+              {
+                closedReview: managerComment,
+              }
+            );
             await processDatabase.result.put(
-              "managerComment",
+              "managerComments",
               processRef,
-              managerCommentState
+              comments
             );
           }
           await processDatabase.result.put(

--- a/pages/thc/[processRef]/loading.tsx
+++ b/pages/thc/[processRef]/loading.tsx
@@ -9,7 +9,7 @@ import { NextPage } from "next";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
 import { nullAsUndefined } from "null-as-undefined";
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useState, Fragment } from "react";
 import { useAsync } from "react-async-hook";
 import ProgressBar from "../../../components/ProgressBar";
 import { TenancySummary } from "../../../components/TenancySummary";
@@ -527,12 +527,18 @@ export const LoadingPage: NextPage = () => {
           worktray.
         </ErrorMessage>
       )}
-      {loading && <Heading level={HeadingLevels.H2}>Loading</Heading>}
-      <Paragraph>
-        {isInManagerStage || isInClosedStage
-          ? "The system is fetching the information you need for this process."
-          : "The system is updating the information you need for this process so that you can go offline at any point."}
-      </Paragraph>
+
+      {loading && (
+        <Fragment>
+          <Heading level={HeadingLevels.H2}>Loading</Heading>
+          <Paragraph>
+            {isInManagerStage || isInClosedStage
+              ? "The system is fetching the information you need for this process."
+              : "The system is updating the information you need for this process so that you can go offline at any point."}
+          </Paragraph>
+        </Fragment>
+      )}
+
       <ProgressBar
         progress={progress}
         incompleteLabel={errored ? "Error" : "Loading..."}

--- a/pages/thc/[processRef]/manager-review.tsx
+++ b/pages/thc/[processRef]/manager-review.tsx
@@ -65,9 +65,7 @@ const ReviewPage: NextPage = () => {
 
   const comments = Object.assign(
     {
-      closedReview: "",
       managerReview: "",
-      unableToEnterClosedReview: "",
       unableToEnterManagerReview: "",
     },
     managerComments.result,

--- a/pages/thc/[processRef]/unable-to-enter-closed-review.tsx
+++ b/pages/thc/[processRef]/unable-to-enter-closed-review.tsx
@@ -32,19 +32,20 @@ const UnableToEnterClosedReviewPage: NextPage = () => {
   const processDatabase = useDatabase(Storage.ProcessContext);
   const isInManagerStage = isManager(router);
 
-  const managerComment = useDataValue(
+  const managerComments = useDataValue(
     Storage.ProcessContext,
-    "managerComment",
+    "managerComments",
     processRef,
     (values) => (processRef ? values[processRef] : undefined)
   );
 
-  const [managerCommentState, setManagerCommentState] = useState("");
+  const [managerComment, setManagerComment] = useState<string>("");
+
   useEffect(() => {
-    if (managerComment.result !== undefined) {
-      setManagerCommentState(managerComment.result);
+    if (managerComments.result !== undefined) {
+      setManagerComment(managerComments.result.unableToEnterClosedReview);
     }
-  }, [managerComment.result]);
+  }, [managerComments.result]);
 
   const tenants = useDataValue(
     Storage.ExternalContext,
@@ -241,9 +242,9 @@ const UnableToEnterClosedReviewPage: NextPage = () => {
               <Heading level={HeadingLevels.H2}>Manager&apos;s comment</Heading>
             ),
           }}
-          value={managerCommentState}
+          value={managerComment}
           rows={4}
-          onChange={(value): void => setManagerCommentState(value)}
+          onChange={(value): void => setManagerComment(value)}
         />
       )}
       <SubmitButton
@@ -253,11 +254,22 @@ const UnableToEnterClosedReviewPage: NextPage = () => {
           }
 
           if (isInManagerStage) {
-            // FIXME: This will overwrite the existing "managerComment" if there is one
+            const comments = Object.assign(
+              {
+                closedReview: "",
+                managerReview: "",
+                unableToEnterClosedReview: "",
+                unableToEnterManagerReview: "",
+              },
+              managerComments.result,
+              {
+                unableToEnterClosedReview: managerComment,
+              }
+            );
             await processDatabase.result.put(
-              "managerComment",
+              "managerComments",
               processRef,
-              managerCommentState
+              comments
             );
           }
 

--- a/pages/thc/[processRef]/unable-to-enter-manager-review.tsx
+++ b/pages/thc/[processRef]/unable-to-enter-manager-review.tsx
@@ -7,7 +7,7 @@ import {
 } from "lbh-frontend-react";
 import { NextPage } from "next";
 import { useRouter } from "next/router";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { ReviewSection } from "../../../components/ReviewSection";
 import { TenancySummary } from "../../../components/TenancySummary";
 import getProcessRef from "../../../helpers/getProcessRef";
@@ -32,6 +32,21 @@ const UnableToEnterManagerReviewPage: NextPage = () => {
   const router = useRouter();
   const processRef = getProcessRef(router);
   const processDatabase = useDatabase(Storage.ProcessContext);
+
+  const managerComments = useDataValue(
+    Storage.ProcessContext,
+    "managerComments",
+    processRef,
+    (values) => (processRef ? values[processRef] : undefined)
+  );
+
+  const [managerComment, setManagerComment] = useState<string>("");
+
+  useEffect(() => {
+    if (managerComments.result !== undefined) {
+      setManagerComment(managerComments.result.unableToEnterManagerReview);
+    }
+  }, [managerComments.result]);
 
   const tenants = useDataValue(
     Storage.ExternalContext,
@@ -121,8 +136,6 @@ const UnableToEnterManagerReviewPage: NextPage = () => {
     true
   );
 
-  const [managerComment, setManagerComment] = useState("");
-
   const allTenantNames = tenantsValue.map(({ fullName }) => fullName);
 
   return (
@@ -192,11 +205,24 @@ const UnableToEnterManagerReviewPage: NextPage = () => {
 
           await approveProcess(router);
 
-          await processDatabase.result.put(
-            "managerComment",
-            processRef,
-            managerComment
+          const comments = Object.assign(
+            {
+              closedReview: "",
+              managerReview: "",
+              unableToEnterClosedReview: "",
+              unableToEnterManagerReview: "",
+            },
+            managerComments.result,
+            {
+              unableToEnterManagerReview: managerComment,
+            }
           );
+          await processDatabase.result.put(
+            "managerComments",
+            processRef,
+            comments
+          );
+
           return true;
         }}
         status={ProcessStage.Approved}
@@ -210,10 +236,22 @@ const UnableToEnterManagerReviewPage: NextPage = () => {
 
           await declineProcess(router);
 
+          const comments = Object.assign(
+            {
+              closedReview: "",
+              managerReview: "",
+              unableToEnterClosedReview: "",
+              unableToEnterManagerReview: "",
+            },
+            managerComments.result,
+            {
+              unableToEnterManagerReview: managerComment,
+            }
+          );
           await processDatabase.result.put(
-            "managerComment",
+            "managerComments",
             processRef,
-            managerComment
+            comments
           );
 
           return true;

--- a/pages/thc/[processRef]/unable-to-enter-manager-review.tsx
+++ b/pages/thc/[processRef]/unable-to-enter-manager-review.tsx
@@ -48,6 +48,17 @@ const UnableToEnterManagerReviewPage: NextPage = () => {
     }
   }, [managerComments.result]);
 
+  const comments = Object.assign(
+    {
+      managerReview: "",
+      unableToEnterManagerReview: "",
+    },
+    managerComments.result,
+    {
+      unableToEnterManagerReview: managerComment,
+    }
+  );
+
   const tenants = useDataValue(
     Storage.ExternalContext,
     "residents",
@@ -205,18 +216,6 @@ const UnableToEnterManagerReviewPage: NextPage = () => {
 
           await approveProcess(router);
 
-          const comments = Object.assign(
-            {
-              closedReview: "",
-              managerReview: "",
-              unableToEnterClosedReview: "",
-              unableToEnterManagerReview: "",
-            },
-            managerComments.result,
-            {
-              unableToEnterManagerReview: managerComment,
-            }
-          );
           await processDatabase.result.put(
             "managerComments",
             processRef,
@@ -236,18 +235,6 @@ const UnableToEnterManagerReviewPage: NextPage = () => {
 
           await declineProcess(router);
 
-          const comments = Object.assign(
-            {
-              closedReview: "",
-              managerReview: "",
-              unableToEnterClosedReview: "",
-              unableToEnterManagerReview: "",
-            },
-            managerComments.result,
-            {
-              unableToEnterManagerReview: managerComment,
-            }
-          );
           await processDatabase.result.put(
             "managerComments",
             processRef,

--- a/storage/ProcessDatabaseSchema.ts
+++ b/storage/ProcessDatabaseSchema.ts
@@ -263,9 +263,7 @@ type ProcessDatabaseSchema = NamedSchema<
     managerComments: {
       key: ProcessRef;
       value: {
-        closedReview: string;
         managerReview: string;
-        unableToEnterClosedReview: string;
         unableToEnterManagerReview: string;
       };
     };
@@ -383,12 +381,7 @@ export const processNotesPaths: {
   ],
   other: ["notes"],
   unableToEnter: [],
-  managerComments: [
-    "closedReview",
-    "managerReview",
-    "unableToEnterClosedReview",
-    "unableToEnterManagerReview",
-  ],
+  managerComments: ["managerReview", "unableToEnterManagerReview"],
 
   // DEPRECATED. DO NOT REMOVE
   managerComment: [],
@@ -574,15 +567,7 @@ export const processPostVisitActionMap: {
     },
   },
   managerComments: {
-    closedReview: {
-      category: "30",
-      subcategory: "XXXXXXX",
-    },
     managerReview: {
-      category: "30",
-      subcategory: "XXXXXXX",
-    },
-    unableToEnterClosedReview: {
       category: "30",
       subcategory: "XXXXXXX",
     },

--- a/storage/ProcessDatabaseSchema.ts
+++ b/storage/ProcessDatabaseSchema.ts
@@ -254,10 +254,23 @@ type ProcessDatabaseSchema = NamedSchema<
           needsFraudInvestigationLetterReminder: boolean;
           fraudInvestigationLetterReminderCreatedAt: string;
         };
+
+        // DEPRECATED. DO NOT REMOVE
         otherNotes: string;
       };
     };
 
+    managerComments: {
+      key: ProcessRef;
+      value: {
+        closedReview: string;
+        managerReview: string;
+        unableToEnterClosedReview: string;
+        unableToEnterManagerReview: string;
+      };
+    };
+
+    // DEPRECATED. DO NOT REMOVE
     managerComment: {
       key: ProcessRef;
       value: string;
@@ -305,6 +318,9 @@ const storeNames: {
   supportNeeds: true,
   other: true,
   unableToEnter: true,
+  managerComments: true,
+
+  // DEPRECATED. DO NOT REMOVE
   managerComment: true,
 };
 
@@ -367,6 +383,14 @@ export const processNotesPaths: {
   ],
   other: ["notes"],
   unableToEnter: [],
+  managerComments: [
+    "closedReview",
+    "managerReview",
+    "unableToEnterClosedReview",
+    "unableToEnterManagerReview",
+  ],
+
+  // DEPRECATED. DO NOT REMOVE
   managerComment: [],
 };
 
@@ -549,6 +573,26 @@ export const processPostVisitActionMap: {
       subcategory: "100000310",
     },
   },
+  managerComments: {
+    closedReview: {
+      category: "30",
+      subcategory: "XXXXXXX",
+    },
+    managerReview: {
+      category: "30",
+      subcategory: "XXXXXXX",
+    },
+    unableToEnterClosedReview: {
+      category: "30",
+      subcategory: "XXXXXXX",
+    },
+    unableToEnterManagerReview: {
+      category: "30",
+      subcategory: "XXXXXXX",
+    },
+  },
+
+  // DEPRECATED. DO NOT REMOVE
   managerComment: {},
 };
 

--- a/storage/databaseSchemaVersion.ts
+++ b/storage/databaseSchemaVersion.ts
@@ -1,1 +1,1 @@
-export default 12;
+export default 13;

--- a/storage/migrations/data/from12.ts
+++ b/storage/migrations/data/from12.ts
@@ -9,14 +9,16 @@ export default <
   processData: T
 ): T => {
   for (const resident of Object.values(processData.residents)) {
-    const { month, year } = resident.carer.liveInStartDate as {
-      month?: number;
-      year?: number;
-    };
-    resident.carer.liveInStartDate = [
-      month === undefined ? `month: ${month}` : "",
-      year === undefined ? `year: ${year}` : "",
-    ].join(" / ");
+    if (resident.carer.liveInStartDate) {
+      const { month, year } = resident.carer.liveInStartDate as {
+        month?: number;
+        year?: number;
+      };
+      resident.carer.liveInStartDate = [
+        month === undefined ? `month: ${month}` : "",
+        year === undefined ? `year: ${year}` : "",
+      ].join(" / ");
+    }
   }
   return processData;
 };

--- a/storage/migrations/data/index.ts
+++ b/storage/migrations/data/index.ts
@@ -1,7 +1,7 @@
-import from12 from "./from12";
 import from3 from "./from3";
 import from4 from "./from4";
 import from8 from "./from8";
+import from12 from "./from12";
 
 export default {
   3: from3,

--- a/storage/migrations/schema/process/from12.ts
+++ b/storage/migrations/schema/process/from12.ts
@@ -1,0 +1,8 @@
+import { Upgrade } from "remultiform/database";
+import ProcessDatabaseSchema from "../../../ProcessDatabaseSchema";
+
+export default (upgrade: Upgrade<ProcessDatabaseSchema["schema"]>): void => {
+  // We don't remove the `managerComment` store, which were removed from
+  // the schema with this version, to guard against data loss.
+  upgrade.createStore("managerComments");
+};

--- a/storage/migrations/schema/process/index.ts
+++ b/storage/migrations/schema/process/index.ts
@@ -2,12 +2,13 @@ import { Upgrade } from "remultiform/database";
 import ProcessDatabaseSchema from "../../../ProcessDatabaseSchema";
 import from0 from "./from0";
 import from1 from "./from1";
-import from10 from "./from10";
-import from11 from "./from11";
 import from2 from "./from2";
 import from3 from "./from3";
 import from6 from "./from6";
 import from7 from "./from7";
+import from10 from "./from10";
+import from11 from "./from11";
+import from12 from "./from12";
 
 export default {
   0: from0,
@@ -18,6 +19,7 @@ export default {
   7: from7,
   10: from10,
   11: from11,
+  12: from12,
 } as {
   [n: number]:
     | ((upgrade: Upgrade<ProcessDatabaseSchema["schema"]>) => void)


### PR DESCRIPTION
the existing manager comments were all stored under the same key in the process database, this means that they would easily have been overwritten.